### PR TITLE
fix: don't fail on `@` and `&`

### DIFF
--- a/__tests__/__snapshots__/util.test.ts.snap
+++ b/__tests__/__snapshots__/util.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pelias string cleaning should strip pelias-unfriendly characters from a string correctly 1`] = `"first street   second street   third street   fourth   fifth"`;
+
 exports[`response merging should filter out 2 identical responses if geocodeEarth response is a bus stop 1`] = `
 Object {
   "features": Array [

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,4 +1,8 @@
-import { arePointsRoughlyEqual, mergeResponses } from '../utils'
+import {
+  arePointsRoughlyEqual,
+  makeQueryPeliasCompatible,
+  mergeResponses
+} from '../utils'
 
 // This is not a real mock, so can be imported using require()
 // eslint-disable-next-line jest/no-mocks-import
@@ -25,6 +29,14 @@ describe('arePointsEqual', () => {
     expect(arePointsRoughlyEqual([9.12342666, 5.7], [9.12348444, 5.7])).toBe(
       false
     )
+  })
+})
+
+describe('pelias string cleaning', () => {
+  it('should strip pelias-unfriendly characters from a string correctly', () => {
+    const badString =
+      'first street @ second street & third street @ fourth & fifth'
+    expect(makeQueryPeliasCompatible(badString)).toMatchSnapshot()
   })
 })
 

--- a/handler.ts
+++ b/handler.ts
@@ -64,7 +64,7 @@ export const makePeliasRequests = async (
   event: ServerlessEvent,
   apiMethod: string
 ): Promise<ServerlessResponse> => {
-  // "Clean" the text parameter to ensure the user's query
+  // "Clean" the text parameter to ensure the user's query is understood by Pelias
   event.queryStringParameters.text = makeQueryPeliasCompatible(
     event.queryStringParameters.text
   )

--- a/handler.ts
+++ b/handler.ts
@@ -16,7 +16,7 @@ import type {
   ServerlessCallbackFunction,
   ServerlessResponse
 } from './utils'
-import { fetchPelias, mergeResponses } from './utils'
+import { fetchPelias, makeQueryPeliasCompatible, mergeResponses } from './utils'
 
 // This plugin must be imported via cjs to ensure its existence (typescript recommendation)
 const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
@@ -64,6 +64,10 @@ export const makePeliasRequests = async (
   event: ServerlessEvent,
   apiMethod: string
 ): Promise<ServerlessResponse> => {
+  // "Clean" the text parameter to ensure the user's query
+  event.queryStringParameters.text = makeQueryPeliasCompatible(
+    event.queryStringParameters.text
+  )
   // Query parameters are returned in a strange format, so have to be converted
   // to URL parameters before being converted to a string
   const query = new URLSearchParams(event.queryStringParameters).toString()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "outDir": ".build",
     "moduleResolution": "node",
-    "lib": ["es2020"],
+    "lib": ["es2020", "ESNext.String"],
     "rootDir": "./",
     "resolveJsonModule": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "outDir": ".build",
     "moduleResolution": "node",
-    "lib": ["es2015"],
+    "lib": ["es2020"],
     "rootDir": "./",
     "resolveJsonModule": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "outDir": ".build",
     "moduleResolution": "node",
-    "lib": ["es2020", "ESNext.String"],
+    "lib": ["es2015"],
     "rootDir": "./",
     "resolveJsonModule": true
   },

--- a/utils.ts
+++ b/utils.ts
@@ -35,7 +35,7 @@ export type ServerlessResponse = {
  * @returns           The string with invalid characters replaced
  */
 export const makeQueryPeliasCompatible = (queryString: string): string => {
-  return queryString.replace('@', ' ').replace('&', ' ')
+  return queryString.replaceAll('@', ' ').replaceAll('&', ' ')
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -31,7 +31,7 @@ export type ServerlessResponse = {
  * Therefore, they are removed using this method. The search still completes
  * as one would expect: "ab @ c" gets converted to "ab  c" which still matches
  * an item named "ab @ c"
- * @param queryString The string with invalid characters to be cleaned
+ * @param queryString The *URL decoded* string with invalid characters to be cleaned
  * @returns           The string with invalid characters replaced
  */
 export const makeQueryPeliasCompatible = (queryString) => {

--- a/utils.ts
+++ b/utils.ts
@@ -25,6 +25,20 @@ export type ServerlessResponse = {
 }
 
 /**
+ * This method removes all characters Pelias doesn't support.
+ * Unfortunately, these characters not only don't match if they're found in the
+ * elasticsearch record, but make the query fail and return no results.
+ * Therefore, they are removed using this method. The search still completes
+ * as one would expect: "ab @ c" gets converted to "ab  c" which still matches
+ * an item named "ab @ c"
+ * @param queryString The string with invalid characters to be cleaned
+ * @returns           The string with invalid characters replaced
+ */
+export const makeQueryPeliasCompatible = (queryString) => {
+  return queryString.replace('@', ' ').replace('&', ' ')
+}
+
+/**
  * Executes a request on a Pelias instance
  * @param baseUrl URL of the Pelias instance, without a trailing slash
  * @param service The endpoint to make the query to (generally search or autocomplete)

--- a/utils.ts
+++ b/utils.ts
@@ -35,7 +35,7 @@ export type ServerlessResponse = {
  * @returns           The string with invalid characters replaced
  */
 export const makeQueryPeliasCompatible = (queryString: string): string => {
-  return queryString.replaceAll('@', ' ').replaceAll('&', ' ')
+  return queryString.replace('@', ' ').replace('&', ' ')
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -34,7 +34,7 @@ export type ServerlessResponse = {
  * @param queryString The *URL decoded* string with invalid characters to be cleaned
  * @returns           The string with invalid characters replaced
  */
-export const makeQueryPeliasCompatible = (queryString) => {
+export const makeQueryPeliasCompatible = (queryString: string): string => {
   return queryString.replace('@', ' ').replace('&', ' ')
 }
 

--- a/utils.ts
+++ b/utils.ts
@@ -35,7 +35,7 @@ export type ServerlessResponse = {
  * @returns           The string with invalid characters replaced
  */
 export const makeQueryPeliasCompatible = (queryString: string): string => {
-  return queryString.replace('@', ' ').replace('&', ' ')
+  return queryString.replace(/@/g, ' ').replace(/&/g, ' ')
 }
 
 /**


### PR DESCRIPTION
This PR replaces the problematic Pelias characters `@` and `&` with spaces so the custom Pelias instance can "understand" them. 