### PR TITLE
fix(handler): support queries which do not include text parameter

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -65,9 +65,11 @@ export const makePeliasRequests = async (
   apiMethod: string
 ): Promise<ServerlessResponse> => {
   // "Clean" the text parameter to ensure the user's query is understood by Pelias
-  event.queryStringParameters.text = makeQueryPeliasCompatible(
-    event.queryStringParameters.text
-  )
+  if (event?.queryStringParameters?.text) {
+    event.queryStringParameters.text = makeQueryPeliasCompatible(
+      event.queryStringParameters.text
+    )
+  }
   // Query parameters are returned in a strange format, so have to be converted
   // to URL parameters before being converted to a string
   const query = new URLSearchParams(event.queryStringParameters).toString()


### PR DESCRIPTION
Requests which did not include a `text` parameter were failing and causing the function to return no response! This is fixed by checking for the parameter before cleaning it.