### PR TITLE
refactor(serverless.yml): allow function to run in custom AWS VPC

### DIFF
--- a/env.example.yml
+++ b/env.example.yml
@@ -1,3 +1,5 @@
+LAMBDA_EXEC_SG: Insert AWS Security Group ID Here (it must be in the same VPC as the subnet)
+LAMBDA_EXEC_SUBNET: Insert AWS Subnet ID Here (it must be in the same VPC as the security group)
 BUGSNAG_NOTIFIER_KEY: INSERT BUGSNAG NOTIFIER KEY HERE
 GEOCODE_EARTH_API_KEY: INSERT GEOCODE.EARTH API KEY HERE
 GEOCODE_EARTH_URL: https://api.geocode.earth/v1

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,11 @@ service: pelias-stitch
 provider:
   name: aws
   runtime: nodejs12.x
+  vpc:
+    securityGroupIds:
+      - ${self:custom.secrets.LAMBDA_EXEC_SG}
+    subnetIds:
+      - ${self:custom.secrets.LAMBDA_EXEC_SUBNET}
   environment:
     # Pelias instance of Geocode.Earth, with street and landmarks
     GEOCODE_EARTH_URL: ${self:custom.secrets.GEOCODE_EARTH_URL}


### PR DESCRIPTION
This PR allows the stitcher to run in a custom VPC, with IDs read in from the env file. The example config is also updated to reflect the change.