### PR TITLE
fix(util): avoid crash on missing primary response

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -209,7 +209,8 @@ export const mergeResponses = (
   // If a focus point is specified, sort custom features by distance to the focus point
   // This ensures the 3 stops are all relevant.
   if (focusPoint) {
-    responses.customResponse.features.sort((a, b) => {
+    // eslint-disable-next-line prettier/prettier
+    (responses.customResponse.features || []).sort((a, b) => {
       if (
         a &&
         a.geometry.type === 'Point' &&

--- a/utils.ts
+++ b/utils.ts
@@ -202,9 +202,9 @@ export const mergeResponses = (
   // correct information than the GTFS feed.
   // Remove anything from the geocode.earth response that's within 10 meters of a custom result
   responses.primaryResponse.features =
-    responses.primaryResponse.features.filter((feature: Feature) =>
+    responses?.primaryResponse?.features?.filter((feature: Feature) =>
       filterOutDuplicateStops(feature, responses.customResponse.features)
-    )
+    ) || []
 
   // If a focus point is specified, sort custom features by distance to the focus point
   // This ensures the 3 stops are all relevant.


### PR DESCRIPTION
There was a bug that caused a crash if the primary response was missing. This PR corrects that bug.