### PR TITLE
fix: parse boundary as float

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -64,7 +64,7 @@ export const convertQSPToGeocoderArgs = (
     params.get('boundary.rect.max_lat'),
     params.get('boundary.rect.max_lon'),
     params.get('size')
-  ].map((p) => p && parseInt(p))
+  ].map((p) => p && parseFloat(p))
 
   const text = params.get('text')
 


### PR DESCRIPTION
Boundary was being parsed as an int which was causing issues with the number being truncated. 