### PR TITLE
Enable AWS API Gateway Caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@opentripplanner/geocoder": "^1.2.2",
     "geolib": "^3.3.1",
     "node-fetch": "^2.6.1",
+    "serverless-api-gateway-caching": "^1.8.1",
     "serverless-plugin-typescript": "^1.1.9"
   },
   "release": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,8 +17,13 @@ provider:
     CUSTOM_PELIAS_URL: ${self:custom.secrets.CUSTOM_PELIAS_URL}
     # Used to logging to Bugsnag
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
+    # Used to enable CSV source
+    CSV_ENABLED: ${self:custom.secrets.CSV_ENABLED}
 custom:
   secrets: ${file(env.yml)}
+  apiGatewayCaching:
+    enabled: true
+    ttlInSeconds: 3600 # defaults to the maximum allowed: 3600
 functions:
   autocomplete:
     handler: handler.autocomplete
@@ -27,6 +32,8 @@ functions:
           method: get
           cors: true
           path: autocomplete
+          caching:
+            enabled: true
   search:
     handler: handler.search
     events:
@@ -44,3 +51,4 @@ functions:
 plugins:
   - serverless-plugin-typescript
   - serverless-offline
+  - serverless-api-gateway-caching

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,8 @@ functions:
           path: autocomplete
           caching:
             enabled: true
+            cacheKeyParameters:
+              - name: request.querystring.text
   search:
     handler: handler.search
     events:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6804,6 +6804,11 @@ lodash.isboolean@^3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
 
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+
 lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
@@ -8913,6 +8918,14 @@ serialize-javascript@^4.0.0:
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
+
+serverless-api-gateway-caching@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/serverless-api-gateway-caching/-/serverless-api-gateway-caching-1.8.1.tgz#c1365d65c0d49379b279121ed807890978688896"
+  integrity sha512-Kqh9x0F8tq4trInIZ/YmAuR+fTb9moWaP2/jFKcdr+77vDh4cZIkleH+/35nUOGuaNoruHiDlSKALGEp+VsdUw==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.isempty "^4.4.0"
 
 serverless-offline@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This PR enables the built in AWS caching for all results.

Results are cached for an hour. 

### At the moment, all keys other than `text` are ignored. 
**This means if a user on mobile (with changed focus point) types a string that a desktop user searched for within an hour they will get results that may be far from their current location** 
The boundary can be ignored since that isn't really supposed to change per deployment.

Curious for everyone's thoughts on this. We can add focus point to the cache key list, but this will mean that mobile users typing "a" will fire a brand new request when that probably isn't necessary 