### PR TITLE
Support Geocoder Minimum Query Length

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install packages
         # the IBI Group TSDX fork has some dependency issues

--- a/env.example.yml
+++ b/env.example.yml
@@ -6,3 +6,5 @@ GEOCODE_EARTH_URL: https://api.geocode.earth/v1 # Not needed if geocode.earth is
 CSV_ENABLED: true
 CUSTOM_PELIAS_URL: http://<insert your Pelias endpoint here>/v1
 GEOCODER: HERE # Options: HERE, PELIAS
+REDIS_HOST: (optional) <insert IP of redis host here>
+REDIS_KEY: (optional) <insert redis password here>

--- a/env.example.yml
+++ b/env.example.yml
@@ -8,3 +8,4 @@ CUSTOM_PELIAS_URL: http://<insert your Pelias endpoint here>/v1
 GEOCODER: HERE # Options: HERE, PELIAS
 REDIS_HOST: (optional) <insert IP of redis host here>
 REDIS_KEY: (optional) <insert redis password here>
+GEOCODER_CHAR_MINIMUM: 3 # Set a minimum query text length before making a geocoder request

--- a/handler.ts
+++ b/handler.ts
@@ -111,6 +111,7 @@ export const makeGeocoderRequests = async (
       getPrimaryGeocoder(),
       apiMethod,
       convertQSPToGeocoderArgs(event.queryStringParameters),
+      // @ts-expect-error Redis Typescript types are not friendly
       redis
     ),
     // Should the custom Pelias instance need to be replaced with something different

--- a/handler.ts
+++ b/handler.ts
@@ -156,7 +156,12 @@ module.exports.autocomplete = bugsnagHandler(
   ): Promise<void> => {
     if (redis) {
       // Only autocomplete needs redis
-      await redis.connect()
+      try {
+        await redis.connect()
+      } catch (e) {
+        console.warn('Redis connection failed. Likely already connected')
+        console.log(e)
+      }
     }
 
     const response = await makeGeocoderRequests(event, 'autocomplete')

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@opentripplanner/geocoder": "^1.2.2",
     "geolib": "^3.3.1",
     "node-fetch": "^2.6.1",
+    "redis": "^4.1.0",
     "serverless-plugin-typescript": "^1.1.9"
   },
   "release": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,7 @@ provider:
     REDIS_KEY: ${self:custom.secrets.REDIS_KEY}
     # Used to enable CSV source
     CSV_ENABLED: ${self:custom.secrets.CSV_ENABLED}
+    GEOCODER_CHAR_MINIMUM: ${self:custom.secrets.GEOCODER_CHAR_MINIMUM}
 custom:
   secrets: ${file(env.yml)}
   apiGatewayCaching:

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,8 @@ provider:
     CUSTOM_PELIAS_URL: ${self:custom.secrets.CUSTOM_PELIAS_URL}
     # Used to logging to Bugsnag
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
+    REDIS_HOST: ${self:custom.secrets.REDIS_HOST}
+    REDIS_KEY: ${self:custom.secrets.REDIS_KEY}
 custom:
   secrets: ${file(env.yml)}
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@
 service: pelias-stitch
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   vpc:
     securityGroupIds:
       - ${self:custom.secrets.LAMBDA_EXEC_SG}

--- a/utils.ts
+++ b/utils.ts
@@ -253,7 +253,9 @@ export const cachedGeocoderRequest = async (
   redisClient: RedisClientType | null
 ): Promise<FeatureCollection> => {
   const { focusPoint, text } = args
+  const { GEOCODER_CHAR_MINIMUM } = process.env
   if (!text) return { features: [], type: 'FeatureCollection' }
+
   const stringifiedFocusPoint = `${focusPoint?.lat}.${focusPoint?.lon}`
   const redisKey = text + stringifiedFocusPoint
 
@@ -263,6 +265,9 @@ export const cachedGeocoderRequest = async (
       return JSON.parse(cachedResponse)
     }
   }
+  if (GEOCODER_CHAR_MINIMUM && text.length <= parseInt(GEOCODER_CHAR_MINIMUM))
+    return { features: [], type: 'FeatureCollection' }
+
   const onlineResponse = await geocoder[requestMethod](args)
   // If we are at this point and have a redis object we know there
   // was no entry in the cache

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,40 @@
     isomorphic-mapzen-search "^1.6.1"
     lodash.memoize "^4.1.2"
 
+"@redis/bloom@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.0.2.tgz#42b82ec399a92db05e29fffcdfd9235a5fc15cdf"
+  integrity sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==
+
+"@redis/client@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.1.0.tgz#e52a85aee802796ceb14bf27daf9550f51f238b8"
+  integrity sha512-xO9JDIgzsZYDl3EvFhl6LC52DP3q3GCMUer8zHgKV6qSYsq1zB+pZs9+T80VgcRogrlRYhi4ZlfX6A+bHiBAgA==
+  dependencies:
+    cluster-key-slot "1.1.0"
+    generic-pool "3.8.2"
+    yallist "4.0.0"
+
+"@redis/graph@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.0.1.tgz#eabc58ba99cd70d0c907169c02b55497e4ec8a99"
+  integrity sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==
+
+"@redis/json@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.3.tgz#a13fde1d22ebff0ae2805cd8e1e70522b08ea866"
+  integrity sha512-4X0Qv0BzD9Zlb0edkUoau5c1bInWSICqXAGrpwEltkncUwcxJIGEcVryZhLgb0p/3PkKaLIWkjhHRtLe9yiA7Q==
+
+"@redis/search@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.0.6.tgz#53d7451c2783f011ebc48ec4c2891264e0b22f10"
+  integrity sha512-pP+ZQRis5P21SD6fjyCeLcQdps+LuTzp2wdUbzxEmNhleighDDTD5ck8+cYof+WLec4csZX7ks+BuoMw0RaZrA==
+
+"@redis/time-series@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.3.tgz#4cfca8e564228c0bddcdf4418cba60c20b224ac4"
+  integrity sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==
+
 "@rollup/plugin-babel@^5.1.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
@@ -3276,6 +3310,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+cluster-key-slot@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
 
 cmd-shim@^4.0.1:
   version "4.1.0"
@@ -4778,6 +4817,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+generic-pool@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.8.2.tgz#aab4f280adb522fdfbdc5e5b64d718d3683f04e9"
+  integrity sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -8479,6 +8523,18 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+redis@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.1.0.tgz#6e400e8edf219e39281afe95e66a3d5f7dcf7289"
+  integrity sha512-5hvJ8wbzpCCiuN1ges6tx2SAh2XXCY0ayresBmu40/SGusWHFW86TAlIPpbimMX2DFHOX7RN34G2XlPA1Z43zg==
+  dependencies:
+    "@redis/bloom" "1.0.2"
+    "@redis/client" "1.1.0"
+    "@redis/graph" "1.0.1"
+    "@redis/json" "1.0.3"
+    "@redis/search" "1.0.6"
+    "@redis/time-series" "1.0.3"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -10295,7 +10351,7 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@^4.0.0:
+yallist@4.0.0, yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
This PR adds support for a new config variable `GEOCODER_CHAR_MINIMUM` that allows you to specify how long the shortest query that gets sent to the geocoder should be. All queries still get sent to Pelias and the Redis cache, if available.