### PR TITLE
Support Fallback Geocoder

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -153,7 +153,7 @@ describe('response rejection', () => {
 
     expect(response).toBe(true)
   })
-  it('should accept a response with all correct layers and correct text', () => {
+  it('should accept a response with all correct layers and correct name', () => {
     const response = checkIfResultsAreSatisfactory(
       {
         features: [
@@ -171,7 +171,7 @@ describe('response rejection', () => {
 
     expect(response).toBe(true)
   })
-  it('should reject a response wtih correct layers, but no text', () => {
+  it('should reject a response with correct layers, but no name', () => {
     const response = checkIfResultsAreSatisfactory(
       {
         features: [
@@ -189,7 +189,7 @@ describe('response rejection', () => {
 
     expect(response).toBe(false)
   })
-  it('should reject a response wtih correct layers, but incorrect text', () => {
+  it('should reject a response with correct layers, but incorrect name', () => {
     const response = checkIfResultsAreSatisfactory(
       {
         features: [
@@ -225,7 +225,7 @@ describe('response rejection', () => {
     )
     expect(evenCloserResponse).toBe(false)
   })
-  it('should reject a response wtih incorrect layers, but correct text', () => {
+  it('should reject a response with incorrect layers, but correct name', () => {
     const response = checkIfResultsAreSatisfactory(
       {
         features: [

--- a/env.example.yml
+++ b/env.example.yml
@@ -6,5 +6,10 @@ GEOCODE_EARTH_URL: https://api.geocode.earth/v1 # Not needed if geocode.earth is
 CSV_ENABLED: true
 CUSTOM_PELIAS_URL: http://<insert your Pelias endpoint here>/v1
 GEOCODER: HERE # Options: HERE, PELIAS
+
+SECONDARY_GEOCODER: (optional) HERE/PELIAS
+SECONDARY_GEOCODER_API_KEY: (optional) INSERT SECONDARY API KEY HERE
+SECONDARY_GEOCODE_EARTH_URL: (optional) https://api.geocode.earth/v1 # Not needed if geocode.earth is not used
+
 REDIS_HOST: (optional) <insert IP of redis host here>
 REDIS_KEY: (optional) <insert redis password here>

--- a/handler.ts
+++ b/handler.ts
@@ -152,7 +152,7 @@ export const makeGeocoderRequests = async (
   ])
 
   // If the primary response doesn't contain responses or the responses are not satisfactory,
-  // run a second (non-cached) request with the secondary geocoder, but only if it exists.
+  // run a second (non-cached) request with the secondary geocoder, but only if one is configured.
   const secondaryGeocoder = getSecondaryGeocoder()
   if (
     secondaryGeocoder &&

--- a/handler.ts
+++ b/handler.ts
@@ -14,6 +14,7 @@ import type { FeatureCollection } from 'geojson'
 
 import {
   cachedGeocoderRequest,
+  checkIfResultsAreSatisfactory,
   convertQSPToGeocoderArgs,
   fetchPelias,
   makeQueryPeliasCompatible,
@@ -33,7 +34,10 @@ const {
   GEOCODER,
   GEOCODER_API_KEY,
   REDIS_HOST,
-  REDIS_KEY
+  REDIS_KEY,
+  SECONDARY_GEOCODE_EARTH_URL,
+  SECONDARY_GEOCODER,
+  SECONDARY_GEOCODER_API_KEY
 } = process.env
 
 const redis = REDIS_HOST
@@ -80,6 +84,28 @@ const getPrimaryGeocoder = () => {
   })
 }
 
+const getSecondaryGeocoder = () => {
+  if (!SECONDARY_GEOCODER || !SECONDARY_GEOCODER_API_KEY) {
+    console.warn('Not using secondary Geocoder')
+    return false
+  }
+
+  if (
+    SECONDARY_GEOCODER === 'PELIAS' &&
+    typeof SECONDARY_GEOCODE_EARTH_URL !== 'string'
+  ) {
+    throw new Error(
+      'Secondary geocoder configured incorrectly: Geocode.earth URL not set.'
+    )
+  }
+  return getGeocoder({
+    apiKey: SECONDARY_GEOCODER_API_KEY,
+    baseUrl: SECONDARY_GEOCODE_EARTH_URL,
+    reverseUseFeatureCollection: true,
+    type: SECONDARY_GEOCODER
+  })
+}
+
 /**
  * Makes a call to a Pelias Instance using secrets from the config file.
  * Includes special query parameters needed for each type of server.
@@ -103,7 +129,7 @@ export const makeGeocoderRequests = async (
   const query = new URLSearchParams(event.queryStringParameters).toString()
 
   // Run both requests in parallel
-  const [primaryResponse, customResponse]: [
+  let [primaryResponse, customResponse]: [
     FeatureCollection,
     FeatureCollection
   ] = await Promise.all([
@@ -124,6 +150,22 @@ export const makeGeocoderRequests = async (
       }`
     )
   ])
+
+  // If the primary response doesn't contain responses or the responses are not satisfactory,
+  // run a second (non-cached) request with the secondary geocoder, but only if it exists.
+  const secondaryGeocoder = getSecondaryGeocoder()
+  if (
+    secondaryGeocoder &&
+    !checkIfResultsAreSatisfactory(
+      primaryResponse,
+      event.queryStringParameters.text
+    )
+  ) {
+    console.log('Results not satisfactory, falling back on secondary geocoder')
+    primaryResponse = await secondaryGeocoder[apiMethod](
+      convertQSPToGeocoderArgs(event.queryStringParameters)
+    )
+  }
 
   const mergedResponse = mergeResponses({
     customResponse,

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,10 @@ provider:
     REDIS_KEY: ${self:custom.secrets.REDIS_KEY}
     # Used to enable CSV source
     CSV_ENABLED: ${self:custom.secrets.CSV_ENABLED}
+    # Secondary Geocoder config
+    SECONDARY_GEOCODER: ${self:custom.secrets.SECONDARY_GEOCODER}
+    SECONDARY_GEOCODER_API_KEY: ${self:custom.secrets.SECONDARY_GEOCODER_API_KEY}
+    SECONDARY_GEOCODE_EARTH_URL: ${self:custom.secrets.SECONDARY_GEOCODE_EARTH_URL}
 custom:
   secrets: ${file(env.yml)}
   apiGatewayCaching:

--- a/utils.ts
+++ b/utils.ts
@@ -276,3 +276,47 @@ export const cachedGeocoderRequest = async (
 
   return onlineResponse
 }
+
+/**
+ * Checks if a feature collection provides "satisfactory" results for a given queryString.
+ * Satisfactory is defined as having results, having results where at least one is of a set of
+ * preferred layers, and as at least one of the results containing all characters present in the
+ * query string.
+ *
+ * This method does two passes over the array for readability -- the temporal difference to doing
+ * some form of reducer is minimal.
+ *
+ * @param featureCollection The GeoJSON featureCollection to check
+ * @param queryString       The query string which the featureCollection results are supposed to represent
+ * @returns                 true if the results are deemed satisfactory, false otherwise
+ */
+export const checkIfResultsAreSatisfactory = (
+  featureCollection: FeatureCollection,
+  queryString: string
+): boolean => {
+  const { features } = featureCollection
+  const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
+
+  // Check for zero length
+  if (features.length === 0) return false
+
+  // Check for at least one layer being one of the preferred layers
+  if (
+    !features.find((feature) =>
+      PREFERRED_LAYERS.includes(feature?.properties?.layer)
+    )
+  )
+    return false
+
+  // Check that at least one result contains the query string
+  if (
+    !features.find((feature) =>
+      feature?.properties?.name
+        ?.toLowerCase()
+        .includes(queryString.toLowerCase())
+    )
+  )
+    return false
+
+  return true
+}

--- a/utils.ts
+++ b/utils.ts
@@ -280,8 +280,7 @@ export const cachedGeocoderRequest = async (
 /**
  * Checks if a feature collection provides "satisfactory" results for a given queryString.
  * Satisfactory is defined as having results, having results where at least one is of a set of
- * preferred layers, and as at least one of the results containing all characters present in the
- * query string.
+ * preferred layers, and as at least one of the results contains the entirety of the query string.
  *
  * This method does two passes over the array for readability -- the temporal difference to doing
  * some form of reducer is minimal.

--- a/utils.ts
+++ b/utils.ts
@@ -301,7 +301,7 @@ export const checkIfResultsAreSatisfactory = (
 
   // Check for at least one layer being one of the preferred layers
   if (
-    !features.find((feature) =>
+    !features.some((feature) =>
       PREFERRED_LAYERS.includes(feature?.properties?.layer)
     )
   )
@@ -309,7 +309,7 @@ export const checkIfResultsAreSatisfactory = (
 
   // Check that the query string is present in at least one returned string
   if (
-    !features.find((feature) =>
+    !features.some((feature) =>
       feature?.properties?.name
         ?.toLowerCase()
         .includes(queryString.toLowerCase())

--- a/utils.ts
+++ b/utils.ts
@@ -308,7 +308,7 @@ export const checkIfResultsAreSatisfactory = (
   )
     return false
 
-  // Check that at least one result contains the query string
+  // Check that the query string is present in at least one returned string
   if (
     !features.find((feature) =>
       feature?.properties?.name


### PR DESCRIPTION
This PR adds support for a fallback geocoder -- a new method is used to deem results from the primary geocoder as "unsatisfactory" in which case the second geocoder is used as a fallback and those results are shown instead.

The secondary geocoder results are not cached, but this could perhaps be changed. I've opted not to do this as it didn't flow nicely with the architecture, and the secondary results are rarely retrieved. It's actually quite difficult to find a case where the primary geocoder fails!