### PR TITLE
fix: support layers query parameter

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -126,7 +126,10 @@ export const makeGeocoderRequests = async (
     )
   }
 
-  const query = new URLSearchParams(event.queryStringParameters).toString()
+  // Pelias has different layers, and so needs to ignore the layers parameter
+  // if it is present
+  const peliasQSP = { ...event.queryStringParameters }
+  delete peliasQSP.layers
 
   // Run both requests in parallel
   let [primaryResponse, customResponse]: [
@@ -145,7 +148,7 @@ export const makeGeocoderRequests = async (
     fetchPelias(
       CUSTOM_PELIAS_URL,
       apiMethod,
-      `${query}&sources=transit${
+      `${new URLSearchParams(peliasQSP).toString()}&sources=transit${
         CSV_ENABLED && CSV_ENABLED === 'true' ? ',pelias' : ''
       }`
     )

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@bugsnag/js": "^7.11.0",
     "@bugsnag/plugin-aws-lambda": "^7.11.0",
     "@conveyal/lonlat": "^1.4.1",
-    "@opentripplanner/geocoder": "^1.2.2",
+    "@opentripplanner/geocoder": "^1.3.2",
     "geolib": "^3.3.1",
     "node-fetch": "^2.6.1",
     "redis": "^4.1.0",

--- a/utils.ts
+++ b/utils.ts
@@ -63,6 +63,7 @@ export const convertQSPToGeocoderArgs = (
   ].map((p) => p && parseFloat(p))
 
   const text = params.get('text')
+  const layers = params.get('layers')
 
   if (minLat && minLon && maxLat && maxLon) {
     geocoderArgs.boundary = {
@@ -87,6 +88,7 @@ export const convertQSPToGeocoderArgs = (
 
   // Safe, performant default
   geocoderArgs.size = size || 4
+  geocoderArgs.layers = layers || 'address,venue,street,intersection'
 
   return geocoderArgs
 }

--- a/utils.ts
+++ b/utils.ts
@@ -28,6 +28,9 @@ export type ServerlessResponse = {
   statusCode: number
 }
 
+// Consts
+const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
+
 /**
  * This method removes all characters Pelias doesn't support.
  * Unfortunately, these characters not only don't match if they're found in the
@@ -88,7 +91,7 @@ export const convertQSPToGeocoderArgs = (
 
   // Safe, performant default
   geocoderArgs.size = size || 4
-  geocoderArgs.layers = layers || 'address,venue,street,intersection'
+  geocoderArgs.layers = layers || PREFERRED_LAYERS.join(',')
 
   return geocoderArgs
 }
@@ -296,7 +299,6 @@ export const checkIfResultsAreSatisfactory = (
   queryString: string
 ): boolean => {
   const { features } = featureCollection
-  const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
   // Check for zero length
   if (features?.length === 0) return false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,10 +1852,10 @@
   dependencies:
     "@octokit/openapi-types" "^9.4.0"
 
-"@opentripplanner/geocoder@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.2.2.tgz#dbbb9fb5f9dc395db1464bad85ae04852be979c1"
-  integrity sha512-sSkGYO+A4Mliw4xNDkbzZJOHyT/q5yvoTtPmjDQQwLy6HZgloa0FckFiI38UlQDftDPkrOQN0urrmFAgYqGaZQ==
+"@opentripplanner/geocoder@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.3.2.tgz#cd67132cb00d6089457d33eb1d4526ef47c0914a"
+  integrity sha512-gTkJlAy0lURZxjG/+bm1qx+M2oLdjSuQEOjLaWhHsA/K7kQWRGhIFhe2vKJF1qZJE+sVe2WCHJDmGKO3I/Nvsw==
   dependencies:
     "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
     "@conveyal/lonlat" "^1.4.1"


### PR DESCRIPTION
This PR adds support for specifying layers, and ensuring that those layers are sent to Pelias, but not the custom geocoder.

Blocked by https://github.com/opentripplanner/otp-ui/pull/464 for support on the geocoder end of things. Tests will pass once geocoder package is updated