### PR TITLE
fix(utils.ts): filter out features with identical names

### DIFF
--- a/__tests__/__snapshots__/util.test.ts.snap
+++ b/__tests__/__snapshots__/util.test.ts.snap
@@ -51,6 +51,55 @@ Object {
 }
 `;
 
+exports[`response merging should filter out 2 identical responses if geocodeEarth response has the same name 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          -122.43634,
+          37.793899,
+        ],
+        "type": "Point",
+      },
+      "properties": Object {
+        "accuracy": "point",
+        "confidence": 1,
+        "continent": "North America",
+        "continent_gid": "whosonfirst:continent:102191575",
+        "country": "United States",
+        "country_a": "USA",
+        "country_gid": "whosonfirst:country:85633793",
+        "county": "San Francisco County",
+        "county_a": "SF",
+        "county_gid": "whosonfirst:county:102087579",
+        "gid": "openaddresses:address:us/ca/san_francisco:e8cd038c05c513c8",
+        "housenumber": "2640",
+        "id": "us/ca/san_francisco:e8cd038c05c513c8",
+        "label": "2640 Steiner St, San Francisco, CA, USA",
+        "layer": "address",
+        "locality": "San Francisco",
+        "locality_a": "SF",
+        "locality_gid": "whosonfirst:locality:85922583",
+        "match_type": "exact",
+        "name": "2640 Steiner St",
+        "neighbourhood": "Pacific Heights",
+        "neighbourhood_gid": "whosonfirst:neighbourhood:85865909",
+        "postalcode": "94115",
+        "region": "California",
+        "region_a": "CA",
+        "region_gid": "whosonfirst:region:85688637",
+        "source": "openaddresses",
+        "source_id": "us/ca/san_francisco:e8cd038c05c513c8",
+        "street": "Steiner St",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;
+
 exports[`response merging should filter out 2 identical responses if geocodeEarth response is a bus stop 1`] = `
 Object {
   "features": Array [
@@ -465,7 +514,7 @@ Object {
         "locality_a": "SF",
         "locality_gid": "whosonfirst:locality:85922583",
         "match_type": "exact",
-        "name": "2640 Steiner St",
+        "name": "2641 Steiner st",
         "neighbourhood": "Pacific Heights",
         "neighbourhood_gid": "whosonfirst:neighbourhood:85865909",
         "postalcode": "94115",

--- a/__tests__/json-mocks/geocode-earth-response-bus-same-name.json
+++ b/__tests__/json-mocks/geocode-earth-response-bus-same-name.json
@@ -13,7 +13,7 @@
         "layer": "address",
         "source": "openaddresses",
         "source_id": "us/ca/san_francisco:e8cd038c05c513c8",
-        "name": "2641 Steiner st",
+        "name": "2640 Steiner st",
         "housenumber": "2640",
         "street": "Steiner St",
         "postalcode": "94115",

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -15,6 +15,8 @@ const GEOCODE_EARTH_RESPONSE =
   require('./json-mocks/geocode-earth-response.json') as FeatureCollection
 const GEOCODE_EARTH_RESPONSE_BUS =
   require('./json-mocks/geocode-earth-response-bus.json') as FeatureCollection
+const GEOCODE_EARTH_RESPONSE_BUS_SAME_NAME =
+  require('./json-mocks/geocode-earth-response-bus-same-name.json') as FeatureCollection
 const HERE_RESPONSE_BUS =
   require('./json-mocks/here-response-bus.json') as FeatureCollection
 
@@ -79,6 +81,13 @@ describe('response merging', () => {
     const merged = mergeResponses({
       customResponse: GEOCODE_EARTH_RESPONSE,
       primaryResponse: GEOCODE_EARTH_RESPONSE_BUS
+    })
+    expect(merged).toMatchSnapshot()
+  })
+  it('should filter out 2 identical responses if geocodeEarth response has the same name', () => {
+    const merged = mergeResponses({
+      customResponse: GEOCODE_EARTH_RESPONSE,
+      primaryResponse: GEOCODE_EARTH_RESPONSE_BUS_SAME_NAME
     })
     expect(merged).toMatchSnapshot()
   })

--- a/utils.ts
+++ b/utils.ts
@@ -148,12 +148,15 @@ const filterOutDuplicateStops = (
   feature: Feature,
   customFeatures: Feature[]
 ): boolean => {
-  // If the names are the same, we can't consider the feature
+  // If the names are the same, or if the feature is too far away, we can't consider the feature
   if (
-    customFeatures.find((otherFeature: Feature) =>
-      feature?.properties?.name
-        .toLowerCase()
-        .includes(otherFeature?.properties?.name.toLowerCase())
+    customFeatures.find(
+      (otherFeature: Feature) =>
+        feature?.properties?.name
+          .toLowerCase()
+          .includes(otherFeature?.properties?.name.toLowerCase()) ||
+        // Any feature this far away is likely not worth being considered
+        feature?.properties?.distance > 7500
     )
   ) {
     return false

--- a/utils.ts
+++ b/utils.ts
@@ -148,7 +148,18 @@ const filterOutDuplicateStops = (
   feature: Feature,
   customFeatures: Feature[]
 ): boolean => {
-  // If the feature to be tested isn't a stop, we don't have to check it.
+  // If the names are the same, we can't consider the feature
+  if (
+    customFeatures.find((otherFeature: Feature) =>
+      feature?.properties?.name
+        .toLowerCase()
+        .includes(otherFeature?.properties?.name.toLowerCase())
+    )
+  ) {
+    return false
+  }
+
+  // If the feature to be tested isn't a stop, we don't have to check its coordinates.
   // In OpenStreetMap, some transit stops have an "operator" tag which is
   // added to the addendum field in Pelias. Therefore, there is still potential
   // for some transit stops without the "operator" tag to still be included in


### PR DESCRIPTION
There are some cases where a custom landmark has the same name as a primary geocoder response. We can use the existing filtering infrastructure to filter these out.