### PR TITLE
Support OTP Geocoder

### DIFF
--- a/env.example.yml
+++ b/env.example.yml
@@ -6,6 +6,8 @@ GEOCODE_EARTH_URL: https://api.geocode.earth/v1 # Not needed if geocode.earth is
 CSV_ENABLED: true
 CUSTOM_PELIAS_URL: http://<insert your Pelias endpoint here>/v1
 GEOCODER: HERE # Options: HERE, PELIAS
+TRANSIT_GEOCODER: (optional) OTP/PELIAS
+TRANSIT_BASE_URL: (conditionally required) OTP instance when TRANSIT_GEOCODER=OTP
 
 SECONDARY_GEOCODER: (optional) HERE/PELIAS
 SECONDARY_GEOCODER_API_KEY: (optional) INSERT SECONDARY API KEY HERE

--- a/handler.ts
+++ b/handler.ts
@@ -61,8 +61,10 @@ if (
   )
 }
 
-if (CSV_ENABLED === "true" && TRANSIT_GEOCODER === 'OTP') {
-  throw new Error("Error: Invalid configuration. OTP Geocoder does not support CSV_ENABLED.")
+if (CSV_ENABLED === 'true' && TRANSIT_GEOCODER === 'OTP') {
+  throw new Error(
+    'Error: Invalid configuration. OTP Geocoder does not support CSV_ENABLED.'
+  )
 }
 
 Bugsnag.start({
@@ -159,18 +161,21 @@ export const makeGeocoderRequests = async (
       // @ts-expect-error Redis Typescript types are not friendly
       redis
     ),
-      // Custom request is either through geocoder package or "old" pelias method 
-      getTransitGeocoder() ? cachedGeocoderRequest(
-        getTransitGeocoder(),
-        'autocomplete',
-        convertQSPToGeocoderArgs(event.queryStringParameters),
-        null
-      ) : fetchPelias(
-        TRANSIT_BASE_URL,
-        apiMethod,
-        `${new URLSearchParams(peliasQSP).toString()}&sources=transit${
-          CSV_ENABLED && CSV_ENABLED === 'true' ? ',pelias' : ''
-        }`)
+    // Custom request is either through geocoder package or "old" pelias method
+    getTransitGeocoder()
+      ? cachedGeocoderRequest(
+          getTransitGeocoder(),
+          'autocomplete',
+          convertQSPToGeocoderArgs(event.queryStringParameters),
+          null
+        )
+      : fetchPelias(
+          TRANSIT_BASE_URL,
+          apiMethod,
+          `${new URLSearchParams(peliasQSP).toString()}&sources=transit${
+            CSV_ENABLED && CSV_ENABLED === 'true' ? ',pelias' : ''
+          }`
+        )
   ])
 
   // If the primary response doesn't contain responses or the responses are not satisfactory,

--- a/handler.ts
+++ b/handler.ts
@@ -57,7 +57,7 @@ if (
   typeof GEOCODER !== 'string'
 ) {
   throw new Error(
-    'Error: required configuration variables not found! Ensure env.yml has been decrypted'
+    'Error: required configuration variables not found! Ensure env.yml has been decrypted.'
   )
 }
 

--- a/handler.ts
+++ b/handler.ts
@@ -51,7 +51,8 @@ if (redis) redis.on('error', (err) => console.log('Redis Client Error', err))
 
 // Ensure env variables have been set
 if (
-  typeof CUSTOM_PELIAS_URL !== 'string' ||
+  typeof TRANSIT_GEOCODER !== 'string' ||
+  typeof TRANSIT_BASE_URL !== 'string' ||
   typeof GEOCODER_API_KEY !== 'string' ||
   typeof BUGSNAG_NOTIFIER_KEY !== 'string' ||
   typeof GEOCODER !== 'string'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@bugsnag/js": "^7.11.0",
     "@bugsnag/plugin-aws-lambda": "^7.11.0",
     "@conveyal/lonlat": "^1.4.1",
-    "@opentripplanner/geocoder": "^1.3.2",
+    "@opentripplanner/geocoder": "^1.4.0",
     "geolib": "^3.3.1",
     "node-fetch": "^2.6.1",
     "redis": "^4.1.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,17 +10,17 @@ provider:
       - ${self:custom.secrets.LAMBDA_EXEC_SUBNET}
   environment:
     GEOCODER: ${self:custom.secrets.GEOCODER}
-    TRANSIT_GEOCODER: ${self:custom.secrets.TRANSIT_GEOCODER}
+    TRANSIT_GEOCODER: ${self:custom.secrets.TRANSIT_GEOCODER, null}
     TRANSIT_BASE_URL: ${self:custom.secrets.TRANSIT_BASE_URL}
     # Pelias instance of Geocode.Earth, with street and landmarks
     GEOCODE_EARTH_URL: ${self:custom.secrets.GEOCODE_EARTH_URL, null}
     GEOCODER_API_KEY: ${self:custom.secrets.GEOCODER_API_KEY, null}
-    # Pelias instance that is self-hosted, with GTFS stops and CSV POIs
-    CUSTOM_PELIAS_URL: ${self:custom.secrets.CUSTOM_PELIAS_URL, null}
     # Used to logging to Bugsnag
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
     REDIS_HOST: ${self:custom.secrets.REDIS_HOST, null}
     REDIS_KEY: ${self:custom.secrets.REDIS_KEY, null}
+    # Used to enable CSV source
+    CSV_ENABLED: ${self:custom.secrets.CSV_ENABLED, false}
     # Secondary Geocoder config
     SECONDARY_GEOCODER: ${self:custom.secrets.SECONDARY_GEOCODER, null}
     SECONDARY_GEOCODER_API_KEY: ${self:custom.secrets.SECONDARY_GEOCODER_API_KEY, null}

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,8 @@ provider:
       - ${self:custom.secrets.LAMBDA_EXEC_SUBNET}
   environment:
     GEOCODER: ${self:custom.secrets.GEOCODER}
+    TRANSIT_GEOCODER: ${self:custom.secrets.TRANSIT_GEOCODER}
+    TRANSIT_BASE_URL: ${self:custom.secrets.TRANSIT_BASE_URL}
     # Pelias instance of Geocode.Earth, with street and landmarks
     GEOCODE_EARTH_URL: ${self:custom.secrets.GEOCODE_EARTH_URL, null}
     GEOCODER_API_KEY: ${self:custom.secrets.GEOCODER_API_KEY, null}
@@ -19,8 +21,6 @@ provider:
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
     REDIS_HOST: ${self:custom.secrets.REDIS_HOST, null}
     REDIS_KEY: ${self:custom.secrets.REDIS_KEY, null}
-    # Used to enable CSV source
-    CSV_ENABLED: ${self:custom.secrets.CSV_ENABLED, false}
     # Secondary Geocoder config
     SECONDARY_GEOCODER: ${self:custom.secrets.SECONDARY_GEOCODER, null}
     SECONDARY_GEOCODER_API_KEY: ${self:custom.secrets.SECONDARY_GEOCODER_API_KEY, null}

--- a/utils.ts
+++ b/utils.ts
@@ -105,10 +105,11 @@ export const convertQSPToGeocoderArgs = (
  * @returns       Pelias response decoded from JSON
  */
 export const fetchPelias = async (
-  baseUrl: string,
-  service: string,
-  query: string
+  baseUrl?: string,
+  service?: string,
+  query?: string
 ): Promise<FeatureCollection> => {
+  if (!baseUrl) return { features: [], type: 'FeatureCollection' }
   try {
     const response = await fetch(`${baseUrl}/${service}?${query}`, {})
     return await response.json()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,10 +1852,10 @@
   dependencies:
     "@octokit/openapi-types" "^9.4.0"
 
-"@opentripplanner/geocoder@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.3.2.tgz#cd67132cb00d6089457d33eb1d4526ef47c0914a"
-  integrity sha512-gTkJlAy0lURZxjG/+bm1qx+M2oLdjSuQEOjLaWhHsA/K7kQWRGhIFhe2vKJF1qZJE+sVe2WCHJDmGKO3I/Nvsw==
+"@opentripplanner/geocoder@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-1.4.0.tgz#728afec6585cf3748a1931493b3a3566421f445d"
+  integrity sha512-FECrLmzYvQmgQDE1Ad19pPdo/HRvz7b0POyD9lXNg/uKTyVXhXxHdYd6sWot6ZiGdiqZTUamNKG3RaWaJvdqoA==
   dependencies:
     "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
     "@conveyal/lonlat" "^1.4.1"


### PR DESCRIPTION
Makes use of https://github.com/opentripplanner/otp-ui/pull/535.

## Config updates (Breaking Change)
- `CUSTOM_PELIAS_URL` is removed, replaced with `TRANSIT_BASE_URL`
- new `TRANSIT_GEOCODER` either one of `pelias` or `otp`