### PR TITLE
fix: expire redis keys after one month

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -291,6 +291,8 @@ export const cachedGeocoderRequest = async (
   if (redisClient) {
     try {
       redisClient.set(redisKey, JSON.stringify(onlineResponse))
+      // 30 day expiry
+      redisClient.expire(redisKey, 30 * 24 * 60 * 60)
     } catch (e) {
       console.warn(`Could not add response to redis cache: ${e}`)
     }


### PR DESCRIPTION
Redis keys were previously not expiring, causing Redis instances to fill up quick and cause problems. This PR resolves this. 