### PR TITLE
Configurable stop filtering radius

### DIFF
--- a/env.example.yml
+++ b/env.example.yml
@@ -4,4 +4,4 @@ BUGSNAG_NOTIFIER_KEY: INSERT BUGSNAG NOTIFIER KEY HERE
 GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`s>
 BACKUP_GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`'s. Same length and order as GEOCODERS>
 
-LOCATION_COMPARISON_COORDIATE_ACCURACY: defaults to 4 (~10m). What accuracy to use when comparing if two locations are the same
+LOCATION_COMPARISON_COORDINATE_PRECISION: defaults to 4 (~10m). What precision to use when comparing if two locations are the same

--- a/env.example.yml
+++ b/env.example.yml
@@ -2,4 +2,6 @@ LAMBDA_EXEC_SG: Insert AWS Security Group ID Here (it must be in the same VPC as
 LAMBDA_EXEC_SUBNET: Insert AWS Subnet ID Here (it must be in the same VPC as the security group)
 BUGSNAG_NOTIFIER_KEY: INSERT BUGSNAG NOTIFIER KEY HERE
 GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`s>
-BACKUP_GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`'s. Same length and order as GEOCODERS> 
+BACKUP_GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`'s. Same length and order as GEOCODERS>
+
+LOCATION_COMPARISON_COORDIATE_ACCURACY: defaults to 4 (~10m). What accuracy to use when comparing if two locations are the same

--- a/env.example.yml
+++ b/env.example.yml
@@ -4,4 +4,4 @@ BUGSNAG_NOTIFIER_KEY: INSERT BUGSNAG NOTIFIER KEY HERE
 GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`s>
 BACKUP_GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`'s. Same length and order as GEOCODERS>
 
-LOCATION_COMPARISON_COORDINATE_PRECISION: defaults to 4 (~10m). What precision to use when comparing if two locations are the same
+COORDINATE_COMPARISON_PRECISION_DIGITS: defaults to 4 (~10m). What precision to use when comparing if two locations are the same

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/js": "^7.11.0",
     "@bugsnag/plugin-aws-lambda": "^7.11.0",
     "@conveyal/lonlat": "^1.4.1",
-    "@opentripplanner/geocoder": "^2.2.0",
+    "@opentripplanner/geocoder": "^2.2.1",
     "geolib": "^3.3.1",
     "node-fetch": "^2.6.1",
     "serverless-api-gateway-caching": "^1.8.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
     GEOCODERS: ${self:custom.secrets.GEOCODERS}
     BACKUP_GEOCODERS: ${self:custom.secrets.BACKUP_GEOCODERS}
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
+    LOCATION_COMPARISON_COORDIATE_ACCURACY: ${self:custom.secrets.LOCATION_COMPARISON_COORDIATE_ACCURACY, 4}
 package:
   patterns:
     - pois.json

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,7 +12,7 @@ provider:
     GEOCODERS: ${self:custom.secrets.GEOCODERS}
     BACKUP_GEOCODERS: ${self:custom.secrets.BACKUP_GEOCODERS}
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
-    LOCATION_COMPARISON_COORDIATE_ACCURACY: ${self:custom.secrets.LOCATION_COMPARISON_COORDIATE_ACCURACY, 4}
+    LOCATION_COMPARISON_COORDINATE_PRECISION: ${self:custom.secrets.LOCATION_COMPARISON_COORDINATE_PRECISION, 4}
 package:
   patterns:
     - pois.json

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,7 +12,7 @@ provider:
     GEOCODERS: ${self:custom.secrets.GEOCODERS}
     BACKUP_GEOCODERS: ${self:custom.secrets.BACKUP_GEOCODERS}
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
-    LOCATION_COMPARISON_COORDINATE_PRECISION: ${self:custom.secrets.LOCATION_COMPARISON_COORDINATE_PRECISION, 4}
+    COORDINATE_COMPARISON_PRECISION_DIGITS: ${self:custom.secrets.COORDINATE_COMPARISON_PRECISION_DIGITS, 4}
 package:
   patterns:
     - pois.json

--- a/utils.ts
+++ b/utils.ts
@@ -30,6 +30,9 @@ export type ServerlessResponse = {
 // Consts
 const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
+const { LOCATION_COMPARISON_COORDIATE_ACCURACY } = process.env
+
+
 /**
  * This method removes all characters Pelias doesn't support.
  * Unfortunately, these characters not only don't match if they're found in the
@@ -97,17 +100,18 @@ export const convertQSPToGeocoderArgs = (
 
 /**
  * Compares two GeoJSON positions and returns if they are equal within 10m accuracy
- * @param a One GeoJSON Position object
- * @param b One GeoJSON Position Object
+ * @param a         One GeoJSON Position object
+ * @param b         One GeoJSON Position Object
+ * @param precision How many digits after the decimal point to use when comparing
  * @returns True if the positions describe the same place, false if they are different
  */
-export const arePointsRoughlyEqual = (a: Position, b: Position): boolean => {
+export const arePointsRoughlyEqual = (a: Position, b: Position, precision: number = 4): boolean => {
   // 4 decimal places is approximately 10 meters, which is acceptable error
   const aRounded = a?.map((point: number): number =>
-    parseFloat(point?.toFixed(4))
+    parseFloat(point?.toFixed(precision))
   )
   const bRounded = b?.map((point: number): number =>
-    parseFloat(point?.toFixed(4))
+    parseFloat(point?.toFixed(precision))
   )
 
   return (
@@ -174,7 +178,8 @@ const filterOutDuplicateStops = (
     // duplicate
     return arePointsRoughlyEqual(
       feature.geometry.coordinates,
-      otherFeature.geometry.coordinates
+      otherFeature.geometry.coordinates,
+      parseInt(LOCATION_COMPARISON_COORDIATE_ACCURACY || '')
     )
   })
 }

--- a/utils.ts
+++ b/utils.ts
@@ -32,7 +32,6 @@ const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
 const { LOCATION_COMPARISON_COORDIATE_ACCURACY } = process.env
 
-
 /**
  * This method removes all characters Pelias doesn't support.
  * Unfortunately, these characters not only don't match if they're found in the
@@ -105,7 +104,11 @@ export const convertQSPToGeocoderArgs = (
  * @param precision How many digits after the decimal point to use when comparing
  * @returns True if the positions describe the same place, false if they are different
  */
-export const arePointsRoughlyEqual = (a: Position, b: Position, precision: number = 4): boolean => {
+export const arePointsRoughlyEqual = (
+  a: Position,
+  b: Position,
+  precision = 4
+): boolean => {
   // 4 decimal places is approximately 10 meters, which is acceptable error
   const aRounded = a?.map((point: number): number =>
     parseFloat(point?.toFixed(precision))

--- a/utils.ts
+++ b/utils.ts
@@ -182,7 +182,9 @@ const filterOutDuplicateStops = (
     return arePointsRoughlyEqual(
       feature.geometry.coordinates,
       otherFeature.geometry.coordinates,
-      !!LOCATION_COMPARISON_COORDINATE_PRECISION ? parseInt(LOCATION_COMPARISON_COORDINATE_PRECISION) : undefined
+      LOCATION_COMPARISON_COORDINATE_PRECISION
+        ? parseInt(LOCATION_COMPARISON_COORDINATE_PRECISION)
+        : undefined
     )
   })
 }

--- a/utils.ts
+++ b/utils.ts
@@ -30,7 +30,7 @@ export type ServerlessResponse = {
 // Consts
 const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
-const { LOCATION_COMPARISON_COORDINATE_PRECISION } = process.env
+const { COORDINATE_COMPARISON_PRECISION_DIGITS } = process.env
 
 /**
  * This method removes all characters Pelias doesn't support.
@@ -182,8 +182,8 @@ const filterOutDuplicateStops = (
     return arePointsRoughlyEqual(
       feature.geometry.coordinates,
       otherFeature.geometry.coordinates,
-      LOCATION_COMPARISON_COORDINATE_PRECISION
-        ? parseInt(LOCATION_COMPARISON_COORDINATE_PRECISION)
+      COORDINATE_COMPARISON_PRECISION_DIGITS
+        ? parseInt(COORDINATE_COMPARISON_PRECISION_DIGITS)
         : undefined
     )
   })

--- a/utils.ts
+++ b/utils.ts
@@ -30,7 +30,7 @@ export type ServerlessResponse = {
 // Consts
 const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
-const { LOCATION_COMPARISON_COORDIATE_ACCURACY } = process.env
+const { LOCATION_COMPARISON_COORDINATE_PRECISION } = process.env
 
 /**
  * This method removes all characters Pelias doesn't support.
@@ -182,7 +182,7 @@ const filterOutDuplicateStops = (
     return arePointsRoughlyEqual(
       feature.geometry.coordinates,
       otherFeature.geometry.coordinates,
-      parseInt(LOCATION_COMPARISON_COORDIATE_ACCURACY || '')
+      !!LOCATION_COMPARISON_COORDINATE_PRECISION ? parseInt(LOCATION_COMPARISON_COORDINATE_PRECISION) : undefined
     )
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,10 +2521,10 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
-"@opentripplanner/geocoder@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-2.2.0.tgz#071f91664e898b06705c781fddd4f75dfcb3cc3f"
-  integrity sha512-V41WOCIpvwLRHEchBg3vRzGOOxoI+SdxczLGgLGPJ/Q/XiqaTqUgsK8WUv+hAUAGYNxI7jZbx7zdC2pXCH0m4w==
+"@opentripplanner/geocoder@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@opentripplanner/geocoder/-/geocoder-2.2.1.tgz#c833c7a965291daf04e712adcf25a8d4d9c5c065"
+  integrity sha512-JkiydCToqivnz8gN57nx14MmaUoLco/K08xIrafYO6akvZHnwVZGi9enIigfxmAH+y1hu3uCviHgu3ATUmO/NQ==
   dependencies:
     "@conveyal/geocoder-arcgis-geojson" "^0.0.3"
     "@conveyal/lonlat" "^1.4.1"


### PR DESCRIPTION
The stop filtering radius was fixed to 4 digits. Now we can configure that to make it less sensitive.