### PR TITLE
add `CHECK_NAME_DUPLICATES` feature

### DIFF
--- a/env.example.yml
+++ b/env.example.yml
@@ -5,3 +5,4 @@ GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`s>
 BACKUP_GEOCODERS: <Stringified JSON Array of OTP-UI `GeocoderConfig`'s. Same length and order as GEOCODERS>
 
 COORDINATE_COMPARISON_PRECISION_DIGITS: defaults to 4 (~10m). What precision to use when comparing if two locations are the same
+CHECK_NAME_DUPLICATES: defaults to true. If disabled, name-based duplicate checking will be disabled. Useful if your GTFS has common words in its stop names

--- a/handler.ts
+++ b/handler.ts
@@ -24,7 +24,7 @@ import {
 // This plugin must be imported via cjs to ensure its existence (typescript recommendation)
 const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
 
-const { BACKUP_GEOCODERS, BUGSNAG_NOTIFIER_KEY, GEOCODERS } = process.env
+const { BACKUP_GEOCODERS, BUGSNAG_NOTIFIER_KEY, GEOCODERS, CHECK_NAME_DUPLICATES } = process.env
 const POIS = require('./pois.json')
 
 if (!GEOCODERS) {
@@ -128,7 +128,12 @@ export const makeGeocoderRequests = async (
   >(
     (prev, cur, idx) => {
       if (idx === 0) return cur
-      return mergeResponses({ customResponse: cur, primaryResponse: prev })
+      return mergeResponses(
+        { customResponse: cur, primaryResponse: prev },
+        // Default to false
+        CHECK_NAME_DUPLICATES === "false" ? false : true,
+        convertQSPToGeocoderArgs(event.queryStringParameters)?.focusPoint
+      );
     },
     // TODO: clean this reducer up. See https://github.com/ibi-group/pelias-stitch/pull/28#discussion_r1547582739
     { features: [], type: 'FeatureCollection' }

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,7 @@ provider:
     BACKUP_GEOCODERS: ${self:custom.secrets.BACKUP_GEOCODERS}
     BUGSNAG_NOTIFIER_KEY: ${self:custom.secrets.BUGSNAG_NOTIFIER_KEY}
     COORDINATE_COMPARISON_PRECISION_DIGITS: ${self:custom.secrets.COORDINATE_COMPARISON_PRECISION_DIGITS, 4}
+    CHECK_NAME_DUPLICATES: ${self:custom.secrets.CHECK_NAME_DUPLICATES, true}
 package:
   patterns:
     - pois.json

--- a/utils.ts
+++ b/utils.ts
@@ -131,15 +131,16 @@ export const arePointsRoughlyEqual = (
  */
 const filterOutDuplicateStops = (
   feature: Feature,
-  customFeatures: Feature[]
+  customFeatures: Feature[],
+  checkNameDuplicates: boolean
 ): boolean => {
   // If the names are the same, or if the feature is too far away, we can't consider the feature
   if (
     customFeatures.find(
       (otherFeature: Feature) =>
-        (feature?.properties?.name || '')
+        (checkNameDuplicates && (feature?.properties?.name || '')
           .toLowerCase()
-          .includes((otherFeature?.properties?.name || '').toLowerCase()) ||
+          .includes((otherFeature?.properties?.name || '').toLowerCase())) ||
         // Any feature this far away is likely not worth being considered
         feature?.properties?.distance > 7500
     )
@@ -199,14 +200,15 @@ export const mergeResponses = (
     customResponse: FeatureCollection
     primaryResponse: FeatureCollection
   },
-  focusPoint?: LonLatOutput
+  checkNameDuplicates: boolean,
+  focusPoint?: LonLatOutput,
 ): FeatureCollection => {
   // Openstreetmap can sometimes include bus stop info with less
   // correct information than the GTFS feed.
   // Remove anything from the geocode.earth response that's within 10 meters of a custom result
   responses.primaryResponse.features =
     responses?.primaryResponse?.features?.filter((feature: Feature) =>
-      filterOutDuplicateStops(feature, responses.customResponse.features)
+      filterOutDuplicateStops(feature, responses.customResponse.features, checkNameDuplicates)
     ) || []
 
   // If a focus point is specified, sort custom features by distance to the focus point


### PR DESCRIPTION
Adds a new feature `CHECK_NAME_DUPLICATES` in the config which disables name-based duplicate checking. This is helpful when your GTFS has common names in it.