### PR TITLE
make query string check much looser

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -306,13 +306,16 @@ export const checkIfResultsAreSatisfactory = (
   )
     return false
 
-  // Check that the query string is present in at least one returned string
+  // Check that each word from the query string is present in at least one returned string
+  const queryWords = queryString
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
   if (
-    !features?.some((feature) =>
-      feature?.properties?.name
-        ?.toLowerCase()
-        .includes(queryString.toLowerCase())
-    )
+    !features?.some((feature) => {
+      const name = feature?.properties?.name?.toLowerCase() || ''
+      return queryWords.every((word) => name.includes(word))
+    })
   )
     return false
 


### PR DESCRIPTION
We used to check that the entire query string was present in at least one of the feature results from the geocoder for it to be "satisfactory", but this was filtering out results where the actual place name was not an exact match for the user's search. The most common example is cardinal directions, like E -> East. "E Broadway" is not contained in "East Broadway"

This change instead checks if each word is contained in a feature. I kind of feel like this might be so loose to not really be doing anything, but I'm not sure what the original intent was here. It will still make sure Broadway is contained in at least one of the results, which seems good. 