### PR TITLE
Smart filtering

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,6 +1,6 @@
 import { FeatureCollection } from "geojson";
 
-import { checkIfResultsAreSatisfactory, mergeResponses, processAndMergeResponses } from "../utils";
+import { mergeResponses, processAndMergeResponses } from "../utils";
 
 const makeOtpRooseveltResponse = (): FeatureCollection => ({
   type: "FeatureCollection",

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -119,10 +119,13 @@ describe("integration: gibberish search should return no results", () => {
      * satisfactory. With no backup geocoder configured, both should become empty,
      * and the merged result should have 0 features.
      */
-    const merged = await processAndMergeResponses({
-      uncheckedResponses: [makeOtpRooseveltResponse(), emptyPeliasResponse],
-      queryString: "rooseveoaifjsoij",
-    });
+    const merged = await processAndMergeResponses(
+      [
+        { response: makeOtpRooseveltResponse() },
+        { response: emptyPeliasResponse }
+      ],
+      "rooseveoaifjsoij"
+    );
 
     expect(merged.features.length).toBe(0);
   });

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -2,100 +2,100 @@ import { FeatureCollection } from "geojson";
 
 import { checkIfResultsAreSatisfactory, mergeResponses, processAndMergeResponses } from "../utils";
 
+const makeOtpRooseveltResponse = (): FeatureCollection => ({
+  type: "FeatureCollection",
+  features: [
+    {
+      geometry: { type: "Point", coordinates: [-122.315976, 47.676595] },
+      id: "40:N09",
+      properties: {
+        layer: "stops",
+        source: "otp",
+        modes: ["TRAM"],
+        name: "Roosevelt",
+        label: "Roosevelt (Sound Transit)",
+        secondaryLabels: [],
+      },
+      type: "Feature",
+    },
+    {
+      geometry: { type: "Point", coordinates: [-122.317467, 47.675457] },
+      id: "kcm:16440",
+      properties: {
+        layer: "stops",
+        source: "otp",
+        modes: ["BUS"],
+        name: "Roosevelt Station - Bay 5",
+        label: "Roosevelt Station - Bay 5 (Metro Transit 16440)",
+        secondaryLabels: ["Roosevelt Station - Bay 5 (Sound Transit)"],
+      },
+      type: "Feature",
+    },
+  ],
+});
+
+const makePeliasRooseveltResponse = (): FeatureCollection => ({
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-77.017027, 38.863066] },
+      properties: {
+        id: "way/67254524",
+        layer: "venue",
+        source: "openstreetmap",
+        name: "National War College",
+        label: "National War College, Washington, DC, USA",
+      },
+    },
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-87.627439, 41.867708] },
+      properties: {
+        id: "node/3219617154",
+        layer: "venue",
+        source: "openstreetmap",
+        name: "Roosevelt",
+        label: "Roosevelt, Central, Chicago, IL, USA",
+        addendum: {
+          osm: {
+            operator: "Chicago Transit Authority",
+          },
+        },
+      },
+    },
+  ],
+});
+
+const emptyPeliasResponse: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
 /**
  * Integration tests based on live API behavior from the QA instance.
  * These tests model the real responses from the OTP and Pelias geocoders
  * to identify issues with result filtering and merging.
  *
  * IMPORTANT: mergeResponses MUTATES its input objects (it reassigns
- * primaryResponse.features). Each test uses factory functions to produce
- * fresh data and avoid cross-test pollution.
+ * primaryResponse.features). We clone the object each time to ensure the
+ * tests are independent.
  */
-
 describe("integration: roosevelt search", () => {
-  const makeOtpRooseveltResponse = (): FeatureCollection => ({
-    type: "FeatureCollection",
-    features: [
-      {
-        geometry: { type: "Point", coordinates: [-122.315976, 47.676595] },
-        id: "40:N09",
-        properties: {
-          layer: "stops",
-          source: "otp",
-          modes: ["TRAM"],
-          name: "Roosevelt",
-          label: "Roosevelt (Sound Transit)",
-          secondaryLabels: [],
-        },
-        type: "Feature",
-      },
-      {
-        geometry: { type: "Point", coordinates: [-122.317467, 47.675457] },
-        id: "kcm:16440",
-        properties: {
-          layer: "stops",
-          source: "otp",
-          modes: ["BUS"],
-          name: "Roosevelt Station - Bay 5",
-          label: "Roosevelt Station - Bay 5 (Metro Transit 16440)",
-          secondaryLabels: ["Roosevelt Station - Bay 5 (Sound Transit)"],
-        },
-        type: "Feature",
-      },
-    ],
-  });
 
-  const makePeliasRooseveltResponse = (): FeatureCollection => ({
-    type: "FeatureCollection",
-    features: [
-      {
-        type: "Feature",
-        geometry: { type: "Point", coordinates: [-77.017027, 38.863066] },
-        properties: {
-          id: "way/67254524",
-          layer: "venue",
-          source: "openstreetmap",
-          name: "National War College",
-          label: "National War College, Washington, DC, USA",
-        },
-      },
-      {
-        type: "Feature",
-        geometry: { type: "Point", coordinates: [-87.627439, 41.867708] },
-        properties: {
-          id: "node/3219617154",
-          layer: "venue",
-          source: "openstreetmap",
-          name: "Roosevelt",
-          label: "Roosevelt, Central, Chicago, IL, USA",
-          addendum: {
-            osm: {
-              operator: "Chicago Transit Authority",
-            },
-          },
-        },
-      },
-    ],
-  });
-
-  it("should include Roosevelt transit station from OTP geocoder in merged results", () => {
+  // Make sure all the results are merged together
+  it("make sure the merged results include everything", () => {
     const merged = mergeResponses({
       customResponse: makeOtpRooseveltResponse(),
       primaryResponse: makePeliasRooseveltResponse(),
     });
 
+    // has the OTP station
     const rooseveltStation = merged.features.find(
       (f) => f.properties?.name === "Roosevelt" && f.properties?.source === "otp",
     );
     expect(rooseveltStation).toBeDefined();
     expect(rooseveltStation?.properties?.modes).toContain("TRAM");
-  });
-
-  it("should include OTP stops alongside Pelias venue results", () => {
-    const merged = mergeResponses({
-      customResponse: makeOtpRooseveltResponse(),
-      primaryResponse: makePeliasRooseveltResponse(),
-    });
 
     const otpResults = merged.features.filter((f) => f.properties?.source === "otp");
     const peliasResults = merged.features.filter((f) => f.properties?.source !== "otp");
@@ -103,89 +103,15 @@ describe("integration: roosevelt search", () => {
     expect(otpResults.length).toBeGreaterThan(0);
     expect(peliasResults.length).toBeGreaterThan(0);
   });
-
-  it("should reject an OTP-only response as unsatisfactory due to stops layer", () => {
-    /**
-     * OTP results use layer='stops' which is NOT in PREFERRED_LAYERS.
-     * This means a pure OTP response would be considered unsatisfactory,
-     * triggering the backup geocoder path in production.
-     */
-    const isSatisfactory = checkIfResultsAreSatisfactory(makeOtpRooseveltResponse(), "roosevelt");
-    expect(isSatisfactory).toBe(false);
-  });
-
-  it("should accept a Pelias response with venue layer as satisfactory", () => {
-    const isSatisfactory = checkIfResultsAreSatisfactory(
-      makePeliasRooseveltResponse(),
-      "roosevelt",
-    );
-    expect(isSatisfactory).toBe(true);
-  });
 });
 
 describe("integration: gibberish search should return no results", () => {
   /**
-   * The OTP geocoder returns results even for complete gibberish like "rooseveoaifjsoij".
+   * The OTP geocoder returns results even for gibberish like "rooseveoaifjsoij".
    * None of these results contain the query string in their name.
    * checkIfResultsAreSatisfactory should correctly reject these results,
    * and they should be filtered from final output.
    */
-  const makeOtpGibberishResponse = (): FeatureCollection => ({
-    type: "FeatureCollection",
-    features: [
-      {
-        geometry: { type: "Point", coordinates: [-122.315976, 47.676595] },
-        id: "40:N09",
-        properties: {
-          layer: "stops",
-          source: "otp",
-          modes: ["TRAM"],
-          name: "Roosevelt",
-          label: "Roosevelt (Sound Transit)",
-          secondaryLabels: [],
-        },
-        type: "Feature",
-      },
-      {
-        geometry: { type: "Point", coordinates: [-122.317467, 47.675457] },
-        id: "kcm:16440",
-        properties: {
-          layer: "stops",
-          source: "otp",
-          modes: ["BUS"],
-          name: "Roosevelt Station - Bay 5",
-          label: "Roosevelt Station - Bay 5 (Metro Transit 16440)",
-          secondaryLabels: [],
-        },
-        type: "Feature",
-      },
-      {
-        geometry: { type: "Point", coordinates: [-122.67603, 47.550607] },
-        id: "Kitsap:521",
-        properties: {
-          layer: "stops",
-          source: "otp",
-          modes: ["BUS"],
-          name: "Roosevelt at Lansing",
-          label: "Roosevelt at Lansing (Kitsap Transit 364)",
-          secondaryLabels: [],
-        },
-        type: "Feature",
-      },
-    ],
-  });
-
-  it("should reject OTP results for gibberish query (no names match)", () => {
-    /**
-     * None of the OTP results contain "rooseveoaifjsoij" in their name,
-     * so checkIfResultsAreSatisfactory should return false.
-     */
-    const isSatisfactory = checkIfResultsAreSatisfactory(
-      makeOtpGibberishResponse(),
-      "rooseveoaifjsoij",
-    );
-    expect(isSatisfactory).toBe(false);
-  });
 
   it("should produce empty results when processing gibberish OTP with empty Pelias (no backup)", async () => {
     /**
@@ -193,41 +119,12 @@ describe("integration: gibberish search should return no results", () => {
      * satisfactory. With no backup geocoder configured, both should become empty,
      * and the merged result should have 0 features.
      */
-    const emptyPeliasResponse: FeatureCollection = {
-      type: "FeatureCollection",
-      features: [],
-    };
-
     const merged = await processAndMergeResponses({
-      uncheckedResponses: [makeOtpGibberishResponse(), emptyPeliasResponse],
+      uncheckedResponses: [makeOtpRooseveltResponse(), emptyPeliasResponse],
       queryString: "rooseveoaifjsoij",
     });
 
     expect(merged.features.length).toBe(0);
-  });
-
-  it("should not include OTP results whose names do not contain the query string", async () => {
-    /**
-     * Even when OTP returns results, none should survive if they don't match
-     * the query string. processAndMergeResponses should filter out unsatisfactory
-     * responses when no backup is configured.
-     */
-    const emptyPeliasResponse: FeatureCollection = {
-      type: "FeatureCollection",
-      features: [],
-    };
-
-    const merged = await processAndMergeResponses({
-      uncheckedResponses: [makeOtpGibberishResponse(), emptyPeliasResponse],
-      queryString: "rooseveoaifjsoij",
-    });
-
-    const nonMatchingResults = merged.features.filter((f) => {
-      const name = f.properties?.name?.toLowerCase() || "";
-      return !name.includes("rooseveoaifjsoij");
-    });
-
-    expect(nonMatchingResults.length).toBe(0);
   });
 });
 
@@ -292,27 +189,9 @@ describe("integration: Stadium search should combine OTP and Pelias results", ()
     ],
   });
 
-  it("should include OTP Stadium station in merged results", () => {
-    const merged = mergeResponses({
-      customResponse: makeOtpStadiumResponse(),
-      primaryResponse: makePeliasStadiumResponse(),
-    });
-
-    const stadiumStation = merged.features.find(
-      (f) => f.properties?.name === "Stadium" && f.properties?.source === "otp",
-    );
-    expect(stadiumStation).toBeDefined();
-    expect(stadiumStation?.properties?.modes).toContain("TRAM");
-  });
-
   it("should include Pelias venue results with Stadium in the name", () => {
-    /**
-     * BUG: The Pelias venues "Rose Bowl Stadium" and "Ben Hill Griffin Stadium" are
-     * filtered out by filterOutDuplicateStops. The dedup logic checks if any Pelias
-     * feature name contains any OTP feature name (case-insensitive). Since the OTP
-     * stop is named "Stadium", and both Pelias venue names contain "stadium", they
-     * are incorrectly treated as duplicates and removed.
-     */
+    // There was a bug where Pelias venues with any word that matched a word in an
+    // OTP result would get filtered out/deduplicated.
     const merged = mergeResponses({
       customResponse: makeOtpStadiumResponse(),
       primaryResponse: makePeliasStadiumResponse(),
@@ -323,39 +202,11 @@ describe("integration: Stadium search should combine OTP and Pelias results", ()
         f.properties?.layer === "venue" && f.properties?.name?.toLowerCase().includes("stadium"),
     );
     expect(peliasStadiums.length).toBeGreaterThan(0);
-  });
 
-  it("should contain both OTP and Pelias sources in final results", () => {
-    /**
-     * BUG: Same root cause as above — Pelias venues get deduplicated because their
-     * names contain the OTP stop name "Stadium".
-     */
-    const merged = mergeResponses({
-      customResponse: makeOtpStadiumResponse(),
-      primaryResponse: makePeliasStadiumResponse(),
-    });
-
-    const sources = new Set(merged.features.map((f) => f.properties?.source));
-    expect(sources).toContain("otp");
-    expect(sources).toContain("openstreetmap");
-  });
-
-  it("should not deduplicate OTP stops and Pelias venues (they are different places)", () => {
-    /**
-     * BUG: Overly aggressive name dedup causes Pelias stadium venues to be removed
-     * when an OTP stop named "Stadium" exists. These are completely different places
-     * at different locations.
-     */
-    const merged = mergeResponses({
-      customResponse: makeOtpStadiumResponse(),
-      primaryResponse: makePeliasStadiumResponse(),
-    });
-
-    // Stadium station from OTP and stadium venues from Pelias are different places
-    // They should all be present
-    const totalFeatures = merged.features.length;
-    expect(totalFeatures).toBe(
-      makeOtpStadiumResponse().features.length + makePeliasStadiumResponse().features.length,
+    const stadiumStation = merged.features.find(
+      (f) => f.properties?.name === "Stadium" && f.properties?.source === "otp",
     );
+    expect(stadiumStation).toBeDefined();
+    expect(stadiumStation?.properties?.modes).toContain("TRAM");
   });
 });

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,0 +1,361 @@
+import { FeatureCollection } from "geojson";
+
+import { checkIfResultsAreSatisfactory, mergeResponses, processAndMergeResponses } from "../utils";
+
+/**
+ * Integration tests based on live API behavior from the QA instance.
+ * These tests model the real responses from the OTP and Pelias geocoders
+ * to identify issues with result filtering and merging.
+ *
+ * IMPORTANT: mergeResponses MUTATES its input objects (it reassigns
+ * primaryResponse.features). Each test uses factory functions to produce
+ * fresh data and avoid cross-test pollution.
+ */
+
+describe("integration: roosevelt search", () => {
+  const makeOtpRooseveltResponse = (): FeatureCollection => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        geometry: { type: "Point", coordinates: [-122.315976, 47.676595] },
+        id: "40:N09",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["TRAM"],
+          name: "Roosevelt",
+          label: "Roosevelt (Sound Transit)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+      {
+        geometry: { type: "Point", coordinates: [-122.317467, 47.675457] },
+        id: "kcm:16440",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["BUS"],
+          name: "Roosevelt Station - Bay 5",
+          label: "Roosevelt Station - Bay 5 (Metro Transit 16440)",
+          secondaryLabels: ["Roosevelt Station - Bay 5 (Sound Transit)"],
+        },
+        type: "Feature",
+      },
+    ],
+  });
+
+  const makePeliasRooseveltResponse = (): FeatureCollection => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-77.017027, 38.863066] },
+        properties: {
+          id: "way/67254524",
+          layer: "venue",
+          source: "openstreetmap",
+          name: "National War College",
+          label: "National War College, Washington, DC, USA",
+        },
+      },
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-87.627439, 41.867708] },
+        properties: {
+          id: "node/3219617154",
+          layer: "venue",
+          source: "openstreetmap",
+          name: "Roosevelt",
+          label: "Roosevelt, Central, Chicago, IL, USA",
+          addendum: {
+            osm: {
+              operator: "Chicago Transit Authority",
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  it("should include Roosevelt transit station from OTP geocoder in merged results", () => {
+    const merged = mergeResponses({
+      customResponse: makeOtpRooseveltResponse(),
+      primaryResponse: makePeliasRooseveltResponse(),
+    });
+
+    const rooseveltStation = merged.features.find(
+      (f) => f.properties?.name === "Roosevelt" && f.properties?.source === "otp",
+    );
+    expect(rooseveltStation).toBeDefined();
+    expect(rooseveltStation?.properties?.modes).toContain("TRAM");
+  });
+
+  it("should include OTP stops alongside Pelias venue results", () => {
+    const merged = mergeResponses({
+      customResponse: makeOtpRooseveltResponse(),
+      primaryResponse: makePeliasRooseveltResponse(),
+    });
+
+    const otpResults = merged.features.filter((f) => f.properties?.source === "otp");
+    const peliasResults = merged.features.filter((f) => f.properties?.source !== "otp");
+
+    expect(otpResults.length).toBeGreaterThan(0);
+    expect(peliasResults.length).toBeGreaterThan(0);
+  });
+
+  it("should reject an OTP-only response as unsatisfactory due to stops layer", () => {
+    /**
+     * OTP results use layer='stops' which is NOT in PREFERRED_LAYERS.
+     * This means a pure OTP response would be considered unsatisfactory,
+     * triggering the backup geocoder path in production.
+     */
+    const isSatisfactory = checkIfResultsAreSatisfactory(makeOtpRooseveltResponse(), "roosevelt");
+    expect(isSatisfactory).toBe(false);
+  });
+
+  it("should accept a Pelias response with venue layer as satisfactory", () => {
+    const isSatisfactory = checkIfResultsAreSatisfactory(
+      makePeliasRooseveltResponse(),
+      "roosevelt",
+    );
+    expect(isSatisfactory).toBe(true);
+  });
+});
+
+describe("integration: gibberish search should return no results", () => {
+  /**
+   * The OTP geocoder returns results even for complete gibberish like "rooseveoaifjsoij".
+   * None of these results contain the query string in their name.
+   * checkIfResultsAreSatisfactory should correctly reject these results,
+   * and they should be filtered from final output.
+   */
+  const makeOtpGibberishResponse = (): FeatureCollection => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        geometry: { type: "Point", coordinates: [-122.315976, 47.676595] },
+        id: "40:N09",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["TRAM"],
+          name: "Roosevelt",
+          label: "Roosevelt (Sound Transit)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+      {
+        geometry: { type: "Point", coordinates: [-122.317467, 47.675457] },
+        id: "kcm:16440",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["BUS"],
+          name: "Roosevelt Station - Bay 5",
+          label: "Roosevelt Station - Bay 5 (Metro Transit 16440)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+      {
+        geometry: { type: "Point", coordinates: [-122.67603, 47.550607] },
+        id: "Kitsap:521",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["BUS"],
+          name: "Roosevelt at Lansing",
+          label: "Roosevelt at Lansing (Kitsap Transit 364)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+    ],
+  });
+
+  it("should reject OTP results for gibberish query (no names match)", () => {
+    /**
+     * None of the OTP results contain "rooseveoaifjsoij" in their name,
+     * so checkIfResultsAreSatisfactory should return false.
+     */
+    const isSatisfactory = checkIfResultsAreSatisfactory(
+      makeOtpGibberishResponse(),
+      "rooseveoaifjsoij",
+    );
+    expect(isSatisfactory).toBe(false);
+  });
+
+  it("should produce empty results when processing gibberish OTP with empty Pelias (no backup)", async () => {
+    /**
+     * When OTP returns gibberish and Pelias returns nothing, neither response is
+     * satisfactory. With no backup geocoder configured, both should become empty,
+     * and the merged result should have 0 features.
+     */
+    const emptyPeliasResponse: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [],
+    };
+
+    const merged = await processAndMergeResponses({
+      uncheckedResponses: [makeOtpGibberishResponse(), emptyPeliasResponse],
+      queryString: "rooseveoaifjsoij",
+    });
+
+    expect(merged.features.length).toBe(0);
+  });
+
+  it("should not include OTP results whose names do not contain the query string", async () => {
+    /**
+     * Even when OTP returns results, none should survive if they don't match
+     * the query string. processAndMergeResponses should filter out unsatisfactory
+     * responses when no backup is configured.
+     */
+    const emptyPeliasResponse: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [],
+    };
+
+    const merged = await processAndMergeResponses({
+      uncheckedResponses: [makeOtpGibberishResponse(), emptyPeliasResponse],
+      queryString: "rooseveoaifjsoij",
+    });
+
+    const nonMatchingResults = merged.features.filter((f) => {
+      const name = f.properties?.name?.toLowerCase() || "";
+      return !name.includes("rooseveoaifjsoij");
+    });
+
+    expect(nonMatchingResults.length).toBe(0);
+  });
+});
+
+describe("integration: Stadium search should combine OTP and Pelias results", () => {
+  const makeOtpStadiumResponse = (): FeatureCollection => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        geometry: { type: "Point", coordinates: [-122.327172, 47.591108] },
+        id: "40:C13",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["TRAM"],
+          name: "Stadium",
+          label: "Stadium (Sound Transit)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+      {
+        geometry: { type: "Point", coordinates: [-122.448999, 47.263869] },
+        id: "40:T17",
+        properties: {
+          layer: "stops",
+          source: "otp",
+          modes: ["TRAM"],
+          name: "Stadium District",
+          label: "Stadium District (Sound Transit)",
+          secondaryLabels: [],
+        },
+        type: "Feature",
+      },
+    ],
+  });
+
+  const makePeliasStadiumResponse = (): FeatureCollection => ({
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-118.167396, 34.160102] },
+        properties: {
+          id: "way/5208863",
+          layer: "venue",
+          source: "openstreetmap",
+          name: "Rose Bowl Stadium",
+          label: "Rose Bowl Stadium, Pasadena, CA, USA",
+        },
+      },
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-82.349443, 29.648896] },
+        properties: {
+          id: "way/45719890",
+          layer: "venue",
+          source: "openstreetmap",
+          name: "Ben Hill Griffin Stadium",
+          label: "Ben Hill Griffin Stadium, Gainesville, FL, USA",
+        },
+      },
+    ],
+  });
+
+  it("should include OTP Stadium station in merged results", () => {
+    const merged = mergeResponses({
+      customResponse: makeOtpStadiumResponse(),
+      primaryResponse: makePeliasStadiumResponse(),
+    });
+
+    const stadiumStation = merged.features.find(
+      (f) => f.properties?.name === "Stadium" && f.properties?.source === "otp",
+    );
+    expect(stadiumStation).toBeDefined();
+    expect(stadiumStation?.properties?.modes).toContain("TRAM");
+  });
+
+  it("should include Pelias venue results with Stadium in the name", () => {
+    /**
+     * BUG: The Pelias venues "Rose Bowl Stadium" and "Ben Hill Griffin Stadium" are
+     * filtered out by filterOutDuplicateStops. The dedup logic checks if any Pelias
+     * feature name contains any OTP feature name (case-insensitive). Since the OTP
+     * stop is named "Stadium", and both Pelias venue names contain "stadium", they
+     * are incorrectly treated as duplicates and removed.
+     */
+    const merged = mergeResponses({
+      customResponse: makeOtpStadiumResponse(),
+      primaryResponse: makePeliasStadiumResponse(),
+    });
+
+    const peliasStadiums = merged.features.filter(
+      (f) =>
+        f.properties?.layer === "venue" && f.properties?.name?.toLowerCase().includes("stadium"),
+    );
+    expect(peliasStadiums.length).toBeGreaterThan(0);
+  });
+
+  it("should contain both OTP and Pelias sources in final results", () => {
+    /**
+     * BUG: Same root cause as above — Pelias venues get deduplicated because their
+     * names contain the OTP stop name "Stadium".
+     */
+    const merged = mergeResponses({
+      customResponse: makeOtpStadiumResponse(),
+      primaryResponse: makePeliasStadiumResponse(),
+    });
+
+    const sources = new Set(merged.features.map((f) => f.properties?.source));
+    expect(sources).toContain("otp");
+    expect(sources).toContain("openstreetmap");
+  });
+
+  it("should not deduplicate OTP stops and Pelias venues (they are different places)", () => {
+    /**
+     * BUG: Overly aggressive name dedup causes Pelias stadium venues to be removed
+     * when an OTP stop named "Stadium" exists. These are completely different places
+     * at different locations.
+     */
+    const merged = mergeResponses({
+      customResponse: makeOtpStadiumResponse(),
+      primaryResponse: makePeliasStadiumResponse(),
+    });
+
+    // Stadium station from OTP and stadium venues from Pelias are different places
+    // They should all be present
+    const totalFeatures = merged.features.length;
+    expect(totalFeatures).toBe(
+      makeOtpStadiumResponse().features.length + makePeliasStadiumResponse().features.length,
+    );
+  });
+});

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -105,20 +105,11 @@ describe("integration: roosevelt search", () => {
   });
 });
 
-describe("integration: gibberish search should return no results", () => {
-  /**
-   * The OTP geocoder returns results even for gibberish like "rooseveoaifjsoij".
-   * None of these results contain the query string in their name.
-   * checkIfResultsAreSatisfactory should correctly reject these results,
-   * and they should be filtered from final output.
-   */
+describe("integration: unsatisfactory results handling", () => {
 
-  it("should produce empty results when processing gibberish OTP with empty Pelias (no backup)", async () => {
-    /**
-     * When OTP returns gibberish and Pelias returns nothing, neither response is
-     * satisfactory. With no backup geocoder configured, both should become empty,
-     * and the merged result should have 0 features.
-     */
+  it("should pass through unsatisfactory results when discardUnsatisfactoryResults is not set", async () => {
+    // The OTP results are unsatisfactory (no feature name contains "rooseveoaifjsoij"),
+    // but without discardUnsatisfactoryResults they pass through
     const merged = await processAndMergeResponses(
       [
         { response: makeOtpRooseveltResponse() },
@@ -127,7 +118,39 @@ describe("integration: gibberish search should return no results", () => {
       "rooseveoaifjsoij"
     );
 
+    expect(merged.features.length).toBe(2);
+  });
+
+  it("should discard unsatisfactory results when discardUnsatisfactoryResults is true", async () => {
+    const merged = await processAndMergeResponses(
+      [
+        { response: makeOtpRooseveltResponse(), discardUnsatisfactoryResults: true },
+        { response: emptyPeliasResponse, discardUnsatisfactoryResults: true }
+      ],
+      "rooseveoaifjsoij"
+    );
+
     expect(merged.features.length).toBe(0);
+  });
+
+  it("should use backup geocoder response when results are unsatisfactory and discardUnsatisfactoryResults is true", async () => {
+    const merged = await processAndMergeResponses(
+      [
+        {
+          response: makeOtpRooseveltResponse(),
+          discardUnsatisfactoryResults: true,
+          fetchBackupResponse: async () => makePeliasRooseveltResponse()
+        },
+        { response: emptyPeliasResponse, discardUnsatisfactoryResults: true }
+      ],
+      "rooseveoaifjsoij"
+    );
+
+    // The backup returned the Pelias Roosevelt response (2 features)
+    expect(merged.features.length).toBe(2);
+    expect(merged.features).toEqual(
+      expect.arrayContaining(makePeliasRooseveltResponse().features)
+    );
   });
 });
 

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -127,6 +127,72 @@ describe('response merging', () => {
     expect(mergedFocusedOnBusStop).toMatchSnapshot()
     expect(mergedFocusedOnSteinerStreet).toMatchSnapshot()
   })
+  it('should remove a same-name transit stop when custom feature distance is within 75 km threshold (74 km)', () => {
+    const merged = mergeResponses({
+      customResponse: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [10, 10] },
+            properties: { name: 'Test Stop', distance: 74 },
+            id: 'custom-1'
+          }
+        ]
+      },
+      primaryResponse: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: {
+              name: 'Test Stop',
+              addendum: { osm: { operator: 'Some Operator' } }
+            },
+            id: 'primary-1'
+          }
+        ]
+      }
+    })
+    // The primary transit stop is a duplicate of the custom feature
+    // (same name, custom distance 74 < 75 km threshold), so it should be filtered out
+    expect(merged.features.find((f) => f.id === 'primary-1')).toBeUndefined()
+    expect(merged.features.find((f) => f.id === 'custom-1')).toBeDefined()
+  })
+  it('should keep a same-name transit stop when custom feature distance exceeds 75 km threshold (76 km)', () => {
+    const merged = mergeResponses({
+      customResponse: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [10, 10] },
+            properties: { name: 'Test Stop', distance: 76 },
+            id: 'custom-2'
+          }
+        ]
+      },
+      primaryResponse: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: {
+              name: 'Test Stop',
+              addendum: { osm: { operator: 'Some Operator' } }
+            },
+            id: 'primary-2'
+          }
+        ]
+      }
+    })
+    // The primary transit stop is NOT a duplicate of the custom feature
+    // (same name but custom distance 76 > 75 km threshold), so it should remain
+    expect(merged.features.find((f) => f.id === 'primary-2')).toBeDefined()
+    expect(merged.features.find((f) => f.id === 'custom-2')).toBeDefined()
+  })
 })
 
 describe('response rejection', () => {

--- a/handler.ts
+++ b/handler.ts
@@ -115,6 +115,9 @@ export const makeGeocoderRequests = async (
       )
     },
     queryString: event.queryStringParameters.text,
+    skipSatisfactoryResultsCheck: geocoders.map(
+      (g: Record<string, unknown>) => !!g.skipSatisfactoryResultsCheck
+    ),
     uncheckedResponses
   })
 

--- a/handler.ts
+++ b/handler.ts
@@ -109,22 +109,26 @@ export const makeGeocoderRequests = async (
   // Check if responses are satisfactory, and re-do them if needed
   const responses = await Promise.all(
     uncheckedResponses.map(async (response, index) => {
-      // If backup geocoder is present, and the returned results are garbage, use the backup geocoder
-      // if one is configured. This request will not be cached
-      if (
-        backupGeocoders[index] &&
-        !checkIfResultsAreSatisfactory(
-          response,
-          event.queryStringParameters.text
-        )
-      ) {
+      const isSatisfactory = checkIfResultsAreSatisfactory(
+        response,
+        event.queryStringParameters.text
+      )
+
+      if (isSatisfactory) {
+        return response
+      }
+
+      // Results are not satisfactory, use backup geocoder if one is configured.
+      // This request will not be cached.
+      if (backupGeocoders[index]) {
         const backupGeocoder = getGeocoder(backupGeocoders[index])
         return await backupGeocoder[apiMethod](
           convertQSPToGeocoderArgs(event.queryStringParameters)
         )
       }
 
-      return response
+      // No backup geocoder configured, return empty results
+      return { type: 'FeatureCollection', features: [] }
     })
   )
 

--- a/handler.ts
+++ b/handler.ts
@@ -113,7 +113,7 @@ export const makeGeocoderRequests = async (
       ? async () => {
           const backupGeocoder = getGeocoder(backupGeocoders[i])
           return await backupGeocoder[apiMethod](
-            convertQSPToGeocoderArgs(event.queryStringParameters)
+            convertQSPToGeocoderArgs(peliasQSP)
           )
         }
       : undefined

--- a/handler.ts
+++ b/handler.ts
@@ -7,7 +7,7 @@
  */
 import Bugsnag from '@bugsnag/js'
 import getGeocoder from '@opentripplanner/geocoder'
-import { Geometry, FeatureCollection, GeoJsonProperties } from 'geojson'
+import { FeatureCollection } from 'geojson'
 import { OfflineResponse } from '@opentripplanner/geocoder/lib/apis/offline'
 
 import {
@@ -106,7 +106,7 @@ export const makeGeocoderRequests = async (
     )
   )
 
-  // build an array of geocoder reqsponses,
+  // build an array of geocoder responses,
   // a callback to request the backup geocoder,
   // and options (for now just discardUnsatisfactoryResults)
   const results: GeocoderRequestResult[] = geocoders.map((geocoder, i) => ({

--- a/handler.ts
+++ b/handler.ts
@@ -12,10 +12,9 @@ import { OfflineResponse } from '@opentripplanner/geocoder/lib/apis/offline'
 
 import {
   cachedGeocoderRequest,
-  checkIfResultsAreSatisfactory,
   convertQSPToGeocoderArgs,
   makeQueryPeliasCompatible,
-  mergeResponses,
+  processAndMergeResponses,
   ServerlessCallbackFunction,
   ServerlessEvent,
   ServerlessResponse
@@ -106,48 +105,18 @@ export const makeGeocoderRequests = async (
     )
   )
 
-  // Check if responses are satisfactory, and re-do them if needed
-  const responses = await Promise.all(
-    uncheckedResponses.map(async (response, index) => {
-      const isSatisfactory = checkIfResultsAreSatisfactory(
-        response,
-        event.queryStringParameters.text
-      )
-
-      if (isSatisfactory) {
-        return response
-      }
-
-      // Results are not satisfactory, use backup geocoder if one is configured.
-      // This request will not be cached.
-      if (backupGeocoders[index]) {
-        const backupGeocoder = getGeocoder(backupGeocoders[index])
-        return await backupGeocoder[apiMethod](
-          convertQSPToGeocoderArgs(event.queryStringParameters)
-        )
-      }
-
-      // No backup geocoder configured, return empty results
-      return { type: 'FeatureCollection', features: [] }
-    })
-  )
-
-  const merged = responses.reduce<
-    FeatureCollection<Geometry, GeoJsonProperties>
-  >(
-    (prev, cur, idx) => {
-      if (idx === 0) return cur
-      return mergeResponses(
-        { customResponse: cur, primaryResponse: prev },
-        // Default to true
-        CHECK_NAME_DUPLICATES !== 'false'
-        // TODO: use focus point here to pre-sort results? It's possible to grab
-        // the focus point by calling convertQSPToGeocoderArgs on event.queryStringParameters
+  const merged = await processAndMergeResponses({
+    uncheckedResponses,
+    queryString: event.queryStringParameters.text,
+    fetchBackupResponse: async (index) => {
+      if (!backupGeocoders[index]) return null
+      const backupGeocoder = getGeocoder(backupGeocoders[index])
+      return await backupGeocoder[apiMethod](
+        convertQSPToGeocoderArgs(event.queryStringParameters)
       )
     },
-    // TODO: clean this reducer up. See https://github.com/ibi-group/pelias-stitch/pull/28#discussion_r1547582739
-    { features: [], type: 'FeatureCollection' }
-  )
+    checkNameDuplicates: CHECK_NAME_DUPLICATES !== 'false'
+  })
 
   return {
     body: JSON.stringify(merged),

--- a/handler.ts
+++ b/handler.ts
@@ -13,6 +13,7 @@ import { OfflineResponse } from '@opentripplanner/geocoder/lib/apis/offline'
 import {
   cachedGeocoderRequest,
   convertQSPToGeocoderArgs,
+  GeocoderRequestResult,
   makeQueryPeliasCompatible,
   processAndMergeResponses,
   ServerlessCallbackFunction,
@@ -96,7 +97,7 @@ export const makeGeocoderRequests = async (
   delete peliasQSP.layers
 
   // Run all requests in parallel
-  const uncheckedResponses: FeatureCollection[] = await Promise.all(
+  const primaryResponses: FeatureCollection[] = await Promise.all(
     geocoders.map((geocoder) =>
       cachedGeocoderRequest(getGeocoder(geocoder), apiMethod, {
         ...convertQSPToGeocoderArgs(event.queryStringParameters),
@@ -105,21 +106,24 @@ export const makeGeocoderRequests = async (
     )
   )
 
-  const merged = await processAndMergeResponses({
-    checkNameDuplicates: CHECK_NAME_DUPLICATES !== 'false',
-    fetchBackupResponse: async (index) => {
-      if (!backupGeocoders[index]) return null
-      const backupGeocoder = getGeocoder(backupGeocoders[index])
-      return await backupGeocoder[apiMethod](
-        convertQSPToGeocoderArgs(event.queryStringParameters)
-      )
-    },
-    queryString: event.queryStringParameters.text,
-    skipSatisfactoryResultsCheck: geocoders.map(
-      (g: Record<string, unknown>) => !!g.skipSatisfactoryResultsCheck
-    ),
-    uncheckedResponses
-  })
+  const results: GeocoderRequestResult[] = geocoders.map((geocoder, i) => ({
+    response: primaryResponses[i],
+    skipSatisfactoryResultsCheck: !!geocoder.skipSatisfactoryResultsCheck,
+    fetchBackupResponse: backupGeocoders[i]
+      ? async () => {
+          const backupGeocoder = getGeocoder(backupGeocoders[i])
+          return await backupGeocoder[apiMethod](
+            convertQSPToGeocoderArgs(event.queryStringParameters)
+          )
+        }
+      : undefined
+  }))
+
+  const merged = await processAndMergeResponses(
+    results,
+    event.queryStringParameters.text,
+    CHECK_NAME_DUPLICATES !== 'false'
+  )
 
   return {
     body: JSON.stringify(merged),

--- a/handler.ts
+++ b/handler.ts
@@ -106,7 +106,11 @@ export const makeGeocoderRequests = async (
     )
   )
 
+  // build an array of geocoder reqsponses,
+  // a callback to request the backup geocoder,
+  // and options (for now just discardUnsatisfactoryResults)
   const results: GeocoderRequestResult[] = geocoders.map((geocoder, i) => ({
+    discardUnsatisfactoryResults: !!geocoder.discardUnsatisfactoryResults,
     fetchBackupResponse: backupGeocoders[i]
       ? async () => {
           const backupGeocoder = getGeocoder(backupGeocoders[i])
@@ -115,8 +119,7 @@ export const makeGeocoderRequests = async (
           )
         }
       : undefined,
-    response: primaryResponses[i],
-    skipSatisfactoryResultsCheck: !!geocoder.skipSatisfactoryResultsCheck
+    response: primaryResponses[i]
   }))
 
   const merged = await processAndMergeResponses(

--- a/handler.ts
+++ b/handler.ts
@@ -106,8 +106,7 @@ export const makeGeocoderRequests = async (
   )
 
   const merged = await processAndMergeResponses({
-    uncheckedResponses,
-    queryString: event.queryStringParameters.text,
+    checkNameDuplicates: CHECK_NAME_DUPLICATES !== 'false',
     fetchBackupResponse: async (index) => {
       if (!backupGeocoders[index]) return null
       const backupGeocoder = getGeocoder(backupGeocoders[index])
@@ -115,7 +114,8 @@ export const makeGeocoderRequests = async (
         convertQSPToGeocoderArgs(event.queryStringParameters)
       )
     },
-    checkNameDuplicates: CHECK_NAME_DUPLICATES !== 'false'
+    queryString: event.queryStringParameters.text,
+    uncheckedResponses
   })
 
   return {

--- a/handler.ts
+++ b/handler.ts
@@ -100,7 +100,7 @@ export const makeGeocoderRequests = async (
   const primaryResponses: FeatureCollection[] = await Promise.all(
     geocoders.map((geocoder) =>
       cachedGeocoderRequest(getGeocoder(geocoder), apiMethod, {
-        ...convertQSPToGeocoderArgs(event.queryStringParameters),
+        ...convertQSPToGeocoderArgs(peliasQSP),
         items: pois
       })
     )

--- a/handler.ts
+++ b/handler.ts
@@ -107,8 +107,6 @@ export const makeGeocoderRequests = async (
   )
 
   const results: GeocoderRequestResult[] = geocoders.map((geocoder, i) => ({
-    response: primaryResponses[i],
-    skipSatisfactoryResultsCheck: !!geocoder.skipSatisfactoryResultsCheck,
     fetchBackupResponse: backupGeocoders[i]
       ? async () => {
           const backupGeocoder = getGeocoder(backupGeocoders[i])
@@ -116,7 +114,9 @@ export const makeGeocoderRequests = async (
             convertQSPToGeocoderArgs(peliasQSP)
           )
         }
-      : undefined
+      : undefined,
+    response: primaryResponses[i],
+    skipSatisfactoryResultsCheck: !!geocoder.skipSatisfactoryResultsCheck
   }))
 
   const merged = await processAndMergeResponses(

--- a/utils.ts
+++ b/utils.ts
@@ -6,7 +6,7 @@ import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { getDistance } from 'geolib'
 
-const MAX_KM_SATISFACTORY_CHECK = 75;
+const MAX_KM_SATISFACTORY_CHECK = 75
 
 // Types
 export type ServerlessEvent = {

--- a/utils.ts
+++ b/utils.ts
@@ -6,6 +6,8 @@ import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { getDistance } from 'geolib'
 
+const MAX_KM_SATISFACTORY_CHECK = 7500;
+
 // Types
 export type ServerlessEvent = {
   headers: Record<string, string>
@@ -29,7 +31,7 @@ export type ServerlessResponse = {
 const PELIAS_LAYERS = ['venue', 'address', 'street', 'intersection']
 const PREFERRED_LAYERS = [...PELIAS_LAYERS, 'stops']
 
-const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env
+const coordinateComparisonPrecisionDigits = process.env
   .COORDINATE_COMPARISON_PRECISION_DIGITS
   ? parseInt(process.env.COORDINATE_COMPARISON_PRECISION_DIGITS)
   : undefined
@@ -129,7 +131,7 @@ const featureIsWithinDistance =
   (feature: Feature): boolean => {
     if (feature?.properties?.distance) {
       const distance = feature.properties.distance
-      return distance > distanceMeters
+      return distance < distanceMeters
     }
     return true
   }
@@ -162,7 +164,7 @@ const filterOutDuplicateStops = (
   // Does a similar feature exist in the custom features
   const similarNameCustomFeature = checkNameDuplicates
     ? customFeatures
-        .filter(featureIsWithinDistance(7500))
+        .filter(featureIsWithinDistance(MAX_KM_SATISFACTORY_CHECK))
         .find((otherFeature: Feature) =>
           (feature?.properties?.name || '')
             .toLowerCase()
@@ -182,7 +184,7 @@ const filterOutDuplicateStops = (
       arePointsRoughlyEqual(
         feature.geometry.coordinates,
         otherFeature.geometry.coordinates,
-        COORDINATE_COMPARISON_PRECISION_DIGITS
+        coordinateComparisonPrecisionDigits
       )
   )
   return !hasDuplicateLocation

--- a/utils.ts
+++ b/utils.ts
@@ -234,6 +234,66 @@ export const mergeResponses = (
 }
 
 /**
+ * Processes geocoder responses by checking satisfaction, falling back to backup
+ * geocoders when needed, and merging the results into a single FeatureCollection.
+ *
+ * @param params.uncheckedResponses  - Raw responses from geocoders
+ * @param params.queryString         - The original query string for satisfaction checking
+ * @param params.fetchBackupResponse - Optional async function to fetch a backup response for a given index.
+ *                                     Return null if no backup is configured for that index.
+ * @param params.checkNameDuplicates - Whether to check for name duplicates during merge (default: true)
+ * @returns Merged FeatureCollection
+ */
+export const processAndMergeResponses = async (params: {
+  uncheckedResponses: FeatureCollection[]
+  queryString: string
+  fetchBackupResponse?: (
+    index: number
+  ) => Promise<FeatureCollection | null>
+  checkNameDuplicates?: boolean
+}): Promise<FeatureCollection> => {
+  const {
+    uncheckedResponses,
+    queryString,
+    fetchBackupResponse,
+    checkNameDuplicates = true
+  } = params
+
+  const responses = await Promise.all(
+    uncheckedResponses.map(async (response, index) => {
+      const isSatisfactory = checkIfResultsAreSatisfactory(
+        response,
+        queryString
+      )
+
+      if (isSatisfactory) {
+        return response
+      }
+
+      // Results are not satisfactory, use backup geocoder if one is configured
+      if (fetchBackupResponse) {
+        const backupResponse = await fetchBackupResponse(index)
+        if (backupResponse) return backupResponse
+      }
+
+      // No backup geocoder configured or backup returned null, return empty results
+      return { type: 'FeatureCollection' as const, features: [] }
+    })
+  )
+
+  return responses.reduce<FeatureCollection>(
+    (prev, cur, idx) => {
+      if (idx === 0) return cur
+      return mergeResponses(
+        { customResponse: cur, primaryResponse: prev },
+        checkNameDuplicates
+      )
+    },
+    { features: [], type: 'FeatureCollection' }
+  )
+}
+
+/**
  * Formerly allowed caching requests in Redis store. This method is kept around now
  * in case another caching solution is attempted again in the future
  * @param geocoder        geocoder object returned from geocoder package

--- a/utils.ts
+++ b/utils.ts
@@ -28,7 +28,7 @@ export type ServerlessResponse = {
 }
 
 // Consts
-const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
+const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection', 'stops']
 
 const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env
   .COORDINATE_COMPARISON_PRECISION_DIGITS
@@ -253,17 +253,23 @@ export const processAndMergeResponses = async (params: {
   checkNameDuplicates?: boolean
   fetchBackupResponse?: (index: number) => Promise<FeatureCollection | null>
   queryString: string
+  skipSatisfactoryResultsCheck?: boolean[]
   uncheckedResponses: FeatureCollection[]
 }): Promise<FeatureCollection> => {
   const {
     checkNameDuplicates = true,
     fetchBackupResponse,
     queryString,
+    skipSatisfactoryResultsCheck,
     uncheckedResponses
   } = params
 
   const responses = await Promise.all(
     uncheckedResponses.map(async (response, index) => {
+      if (skipSatisfactoryResultsCheck?.[index]) {
+        return response
+      }
+
       const isSatisfactory = checkIfResultsAreSatisfactory(
         response,
         queryString

--- a/utils.ts
+++ b/utils.ts
@@ -245,9 +245,9 @@ export const mergeResponses = (
  * A single geocoder's response along with its associated configuration.
  */
 export interface GeocoderRequestResult {
+  fetchBackupResponse?: () => Promise<FeatureCollection | null>
   response: FeatureCollection
   skipSatisfactoryResultsCheck?: boolean
-  fetchBackupResponse?: () => Promise<FeatureCollection | null>
 }
 
 /**
@@ -264,31 +264,36 @@ export const processAndMergeResponses = async (
   queryString: string,
   checkNameDuplicates = true
 ): Promise<FeatureCollection> => {
-
   const responses = await Promise.all(
-    results.map(async ({ response, skipSatisfactoryResultsCheck, fetchBackupResponse }) => {
-      if (skipSatisfactoryResultsCheck) {
-        return response
-      }
-
-      const isSatisfactory = checkIfResultsAreSatisfactory(
+    results.map(
+      async ({
+        fetchBackupResponse,
         response,
-        queryString
-      )
+        skipSatisfactoryResultsCheck
+      }) => {
+        if (skipSatisfactoryResultsCheck) {
+          return response
+        }
 
-      if (isSatisfactory) {
-        return response
+        const isSatisfactory = checkIfResultsAreSatisfactory(
+          response,
+          queryString
+        )
+
+        if (isSatisfactory) {
+          return response
+        }
+
+        // Results are not satisfactory, use backup geocoder if one is configured
+        if (fetchBackupResponse) {
+          const backupResponse = await fetchBackupResponse()
+          if (backupResponse) return backupResponse
+        }
+
+        // No backup geocoder configured or backup returned null, return empty results
+        return { features: [], type: 'FeatureCollection' as const }
       }
-
-      // Results are not satisfactory, use backup geocoder if one is configured
-      if (fetchBackupResponse) {
-        const backupResponse = await fetchBackupResponse()
-        if (backupResponse) return backupResponse
-      }
-
-      // No backup geocoder configured or backup returned null, return empty results
-      return { features: [], type: 'FeatureCollection' as const }
-    })
+    )
   )
 
   // Merge the responses together. Order matters here because of duplicate checks

--- a/utils.ts
+++ b/utils.ts
@@ -180,7 +180,9 @@ const filterOutDuplicateStops = (
 /**
  * Merges two Pelias responses together
  * @param responses An object containing two Pelias response objects
- * @returns         A single Pelias response object the features from both input objects
+ * @param checkNameDuplicates Whether to check duplicate names in duplicate check.
+ * @param focusPoint results will be sorted by distance if provided
+ * @returns A single Pelias response object the features from both input objects
  */
 export const mergeResponses = (
   responses: {
@@ -288,6 +290,7 @@ export const processAndMergeResponses = async (
     })
   )
 
+  // Merge the responses together. Order matters here because of duplicate checks
   return responses.reduce<FeatureCollection>(
     (prev, cur, idx) => {
       if (idx === 0) return cur

--- a/utils.ts
+++ b/utils.ts
@@ -1,10 +1,10 @@
+import { URLSearchParams } from 'url'
+
 import { fromCoordinates } from '@conveyal/lonlat'
 import type { LonLatOutput } from '@conveyal/lonlat'
 import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { getDistance } from 'geolib'
-import { URLSearchParams } from 'url'
-
 
 // Types
 export type ServerlessEvent = {
@@ -124,14 +124,15 @@ export const arePointsRoughlyEqual = (
   )
 }
 
-const featureIsWithinDistance = (distanceMeters: number) =>
+const featureIsWithinDistance =
+  (distanceMeters: number) =>
   (feature: Feature): boolean => {
-  if (feature?.properties?.distance) {
-    const distance = feature.properties.distance
-    return distance > distanceMeters
+    if (feature?.properties?.distance) {
+      const distance = feature.properties.distance
+      return distance > distanceMeters
+    }
+    return true
   }
-  return true
-}
 
 /**
  * Inspects a feature and removes it if a similar feature is included within a
@@ -160,11 +161,13 @@ const filterOutDuplicateStops = (
 
   // Does a similar feature exist in the custom features
   const similarNameCustomFeature = checkNameDuplicates
-    ? customFeatures.filter(featureIsWithinDistance(7500)).find((otherFeature: Feature) =>
-        (feature?.properties?.name || '')
-          .toLowerCase()
-          .includes((otherFeature?.properties?.name || '').toLowerCase())
-      )
+    ? customFeatures
+        .filter(featureIsWithinDistance(7500))
+        .find((otherFeature: Feature) =>
+          (feature?.properties?.name || '')
+            .toLowerCase()
+            .includes((otherFeature?.properties?.name || '').toLowerCase())
+        )
     : undefined
 
   if (similarNameCustomFeature) {

--- a/utils.ts
+++ b/utils.ts
@@ -30,7 +30,8 @@ export type ServerlessResponse = {
 // Consts
 const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
-const { COORDINATE_COMPARISON_PRECISION_DIGITS } = process.env
+const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env.COORDINATE_COMPARISON_PRECISION_DIGITS ?
+    parseInt(process.env.COORDINATE_COMPARISON_PRECISION_DIGITS) : undefined
 
 /**
  * This method removes all characters Pelias doesn't support.
@@ -127,68 +128,48 @@ export const arePointsRoughlyEqual = (
  * second list of features
  * @param feature The feature to either keep or remove
  * @param customFeatures The set of features to check against
- * @returns True or false depending on if the feature is unique
+ * @returns True if unique, false if it is a duplicate stop
  */
 const filterOutDuplicateStops = (
   feature: Feature,
   customFeatures: Feature[],
   checkNameDuplicates: boolean
 ): boolean => {
-  // If the names are the same, or if the feature is too far away, we can't consider the feature
-  if (
-    customFeatures.find(
-      (otherFeature: Feature) =>
-        (checkNameDuplicates &&
-          (feature?.properties?.name || '')
-            .toLowerCase()
-            .includes((otherFeature?.properties?.name || '').toLowerCase())) ||
-        // Any feature this far away is likely not worth being considered
-        feature?.properties?.distance > 7500
+  // If the feature isn't a transit stop, we don't need to check its coordinates.
+  // Transit stops are identified by an OSM "operator" tag or HERE public transport
+  // categories (starting with "400-"). Non-transit features are always saved.
+  const isTransitStop =
+    !!feature.properties?.addendum?.osm?.operator ||
+    !!feature.properties?.addendum?.categories?.some((c) =>
+      c.id.startsWith('400-')
     )
-  ) {
-    return false
-  }
 
-  // If the feature to be tested isn't a stop, we don't have to check its coordinates.
-  // In OpenStreetMap, some transit stops have an "operator" tag which is
-  // added to the addendum field in Pelias. Therefore, there is still potential
-  // for some transit stops without the "operator" tag to still be included in
-  // search results.
-  if (
-    !feature.properties ||
-    !feature.properties.addendum ||
-    // if a OSM feature has an operator tag, it is a transit stop
-    ((!feature.properties.addendum.osm ||
-      !feature.properties.addendum.osm.operator) &&
-      // HERE public transport categories start with a 400
-      !feature.properties.addendum.categories?.find(
-        (c) => !!c.id.match(/^400-/)
-      ))
-  ) {
-    // Returning true ensures the Feature is *saved*
+  if (!isTransitStop) {
     return true
   }
 
-  // If a custom feature at the same location *can't* be found, return the Feature
-  return !customFeatures.find((otherFeature: Feature) => {
-    // Check Point data exists before working with it
-    if (
-      feature.geometry.type !== 'Point' ||
-      otherFeature.geometry.type !== 'Point'
-    ) {
-      return null
-    }
+  // Does a similar feature exist in the custom features
+  const similarNameCustomFeature = checkNameDuplicates ? customFeatures.find((otherFeature: Feature) =>
+      (feature?.properties?.name || '')
+        .toLowerCase()
+        .includes((otherFeature?.properties?.name || '').toLowerCase())) : undefined
 
-    // If this is true, we have a match! Which will be negated above to remove the
-    // duplicate
-    return arePointsRoughlyEqual(
-      feature.geometry.coordinates,
-      otherFeature.geometry.coordinates,
-      COORDINATE_COMPARISON_PRECISION_DIGITS
-        ? parseInt(COORDINATE_COMPARISON_PRECISION_DIGITS)
-        : undefined
-    )
-  })
+  if (similarNameCustomFeature) {
+    return false
+  }
+
+  // Save the feature if no custom feature exists at the same location
+  const hasDuplicateLocation = customFeatures.some(
+    (otherFeature: Feature) =>
+      feature.geometry.type === 'Point' &&
+      otherFeature.geometry.type === 'Point' &&
+      arePointsRoughlyEqual(
+        feature.geometry.coordinates,
+        otherFeature.geometry.coordinates,
+        COORDINATE_COMPARISON_PRECISION_DIGITS
+      )
+  )
+  return !hasDuplicateLocation
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -239,34 +239,32 @@ export const mergeResponses = (
 }
 
 /**
- * Processes geocoder responses by checking satisfaction, falling back to backup
+ * A single geocoder's response along with its associated configuration.
+ */
+export interface GeocoderRequestResult {
+  response: FeatureCollection
+  skipSatisfactoryResultsCheck?: boolean
+  fetchBackupResponse?: () => Promise<FeatureCollection | null>
+}
+
+/**
+ * Processes geocoder responses by checking quality and duplicates, falling back to backup
  * geocoders when needed, and merging the results into a single FeatureCollection.
  *
- * @param params.uncheckedResponses  - Raw responses from geocoders
- * @param params.queryString         - The original query string for satisfaction checking
- * @param params.fetchBackupResponse - Optional async function to fetch a backup response for a given index.
- *                                     Return null if no backup is configured for that index.
- * @param params.checkNameDuplicates - Whether to check for name duplicates during merge (default: true)
+ * @param results  array of geocoder results with their associated configuration
+ * @param queryString the original query string for satisfaction checking
+ * @param checkNameDuplicates  whether to check for name duplicates during merge
  * @returns Merged FeatureCollection
  */
-export const processAndMergeResponses = async (params: {
-  checkNameDuplicates?: boolean
-  fetchBackupResponse?: (index: number) => Promise<FeatureCollection | null>
-  queryString: string
-  skipSatisfactoryResultsCheck?: boolean[]
-  uncheckedResponses: FeatureCollection[]
-}): Promise<FeatureCollection> => {
-  const {
-    checkNameDuplicates = true,
-    fetchBackupResponse,
-    queryString,
-    skipSatisfactoryResultsCheck,
-    uncheckedResponses
-  } = params
+export const processAndMergeResponses = async (
+  results: GeocoderRequestResult[],
+  queryString: string,
+  checkNameDuplicates = true
+): Promise<FeatureCollection> => {
 
   const responses = await Promise.all(
-    uncheckedResponses.map(async (response, index) => {
-      if (skipSatisfactoryResultsCheck?.[index]) {
+    results.map(async ({ response, skipSatisfactoryResultsCheck, fetchBackupResponse }) => {
+      if (skipSatisfactoryResultsCheck) {
         return response
       }
 
@@ -281,7 +279,7 @@ export const processAndMergeResponses = async (params: {
 
       // Results are not satisfactory, use backup geocoder if one is configured
       if (fetchBackupResponse) {
-        const backupResponse = await fetchBackupResponse(index)
+        const backupResponse = await fetchBackupResponse()
         if (backupResponse) return backupResponse
       }
 

--- a/utils.ts
+++ b/utils.ts
@@ -245,9 +245,9 @@ export const mergeResponses = (
  * A single geocoder's response along with its associated configuration.
  */
 export interface GeocoderRequestResult {
+  discardUnsatisfactoryResults?: boolean
   fetchBackupResponse?: () => Promise<FeatureCollection | null>
   response: FeatureCollection
-  skipSatisfactoryResultsCheck?: boolean
 }
 
 /**
@@ -267,14 +267,10 @@ export const processAndMergeResponses = async (
   const responses = await Promise.all(
     results.map(
       async ({
+        discardUnsatisfactoryResults,
         fetchBackupResponse,
-        response,
-        skipSatisfactoryResultsCheck
+        response
       }) => {
-        if (skipSatisfactoryResultsCheck) {
-          return response
-        }
-
         const isSatisfactory = checkIfResultsAreSatisfactory(
           response,
           queryString
@@ -285,13 +281,15 @@ export const processAndMergeResponses = async (
         }
 
         // Results are not satisfactory, use backup geocoder if one is configured
-        if (fetchBackupResponse) {
-          const backupResponse = await fetchBackupResponse()
-          if (backupResponse) return backupResponse
+        const backupResponse = fetchBackupResponse
+          ? await fetchBackupResponse()
+          : undefined
+        if (backupResponse) {
+          return backupResponse
+        } else if (discardUnsatisfactoryResults) {
+          return { features: [], type: 'FeatureCollection' as const }
         }
-
-        // No backup geocoder configured or backup returned null, return empty results
-        return { features: [], type: 'FeatureCollection' as const }
+        return response
       }
     )
   )

--- a/utils.ts
+++ b/utils.ts
@@ -30,8 +30,10 @@ export type ServerlessResponse = {
 // Consts
 const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection']
 
-const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env.COORDINATE_COMPARISON_PRECISION_DIGITS ?
-    parseInt(process.env.COORDINATE_COMPARISON_PRECISION_DIGITS) : undefined
+const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env
+  .COORDINATE_COMPARISON_PRECISION_DIGITS
+  ? parseInt(process.env.COORDINATE_COMPARISON_PRECISION_DIGITS)
+  : undefined
 
 /**
  * This method removes all characters Pelias doesn't support.
@@ -149,10 +151,13 @@ const filterOutDuplicateStops = (
   }
 
   // Does a similar feature exist in the custom features
-  const similarNameCustomFeature = checkNameDuplicates ? customFeatures.find((otherFeature: Feature) =>
-      (feature?.properties?.name || '')
-        .toLowerCase()
-        .includes((otherFeature?.properties?.name || '').toLowerCase())) : undefined
+  const similarNameCustomFeature = checkNameDuplicates
+    ? customFeatures.find((otherFeature: Feature) =>
+        (feature?.properties?.name || '')
+          .toLowerCase()
+          .includes((otherFeature?.properties?.name || '').toLowerCase())
+      )
+    : undefined
 
   if (similarNameCustomFeature) {
     return false
@@ -245,18 +250,16 @@ export const mergeResponses = (
  * @returns Merged FeatureCollection
  */
 export const processAndMergeResponses = async (params: {
-  uncheckedResponses: FeatureCollection[]
-  queryString: string
-  fetchBackupResponse?: (
-    index: number
-  ) => Promise<FeatureCollection | null>
   checkNameDuplicates?: boolean
+  fetchBackupResponse?: (index: number) => Promise<FeatureCollection | null>
+  queryString: string
+  uncheckedResponses: FeatureCollection[]
 }): Promise<FeatureCollection> => {
   const {
-    uncheckedResponses,
-    queryString,
+    checkNameDuplicates = true,
     fetchBackupResponse,
-    checkNameDuplicates = true
+    queryString,
+    uncheckedResponses
   } = params
 
   const responses = await Promise.all(
@@ -277,7 +280,7 @@ export const processAndMergeResponses = async (params: {
       }
 
       // No backup geocoder configured or backup returned null, return empty results
-      return { type: 'FeatureCollection' as const, features: [] }
+      return { features: [], type: 'FeatureCollection' as const }
     })
   )
 

--- a/utils.ts
+++ b/utils.ts
@@ -6,7 +6,7 @@ import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { getDistance } from 'geolib'
 
-const MAX_KM_SATISFACTORY_CHECK = 7500;
+const MAX_KM_SATISFACTORY_CHECK = 75;
 
 // Types
 export type ServerlessEvent = {
@@ -127,11 +127,11 @@ export const arePointsRoughlyEqual = (
 }
 
 const featureIsWithinDistance =
-  (distanceMeters: number) =>
+  (distanceKm: number) =>
   (feature: Feature): boolean => {
     if (feature?.properties?.distance) {
       const distance = feature.properties.distance
-      return distance < distanceMeters
+      return distance < distanceKm
     }
     return true
   }

--- a/utils.ts
+++ b/utils.ts
@@ -28,7 +28,8 @@ export type ServerlessResponse = {
 }
 
 // Consts
-const PREFERRED_LAYERS = ['venue', 'address', 'street', 'intersection', 'stops']
+const PELIAS_LAYERS = ['venue', 'address', 'street', 'intersection']
+const PREFERRED_LAYERS = [...PELIAS_LAYERS, 'stops']
 
 const COORDINATE_COMPARISON_PRECISION_DIGITS = process.env
   .COORDINATE_COMPARISON_PRECISION_DIGITS
@@ -95,7 +96,7 @@ export const convertQSPToGeocoderArgs = (
 
   // Safe, performant default
   geocoderArgs.size = size || 4
-  geocoderArgs.layers = layers || PREFERRED_LAYERS.join(',')
+  geocoderArgs.layers = layers || PELIAS_LAYERS.join(',')
 
   return geocoderArgs
 }

--- a/utils.ts
+++ b/utils.ts
@@ -1,12 +1,10 @@
+import { fromCoordinates } from '@conveyal/lonlat'
+import type { LonLatOutput } from '@conveyal/lonlat'
+import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
+import type { Feature, FeatureCollection, Position } from 'geojson'
+import { getDistance } from 'geolib'
 import { URLSearchParams } from 'url'
 
-import bugsnag from '@bugsnag/js'
-import { fromCoordinates } from '@conveyal/lonlat'
-import { getDistance } from 'geolib'
-import fetch from 'node-fetch'
-import type { LonLatOutput } from '@conveyal/lonlat'
-import type { Feature, FeatureCollection, Position } from 'geojson'
-import { AnyGeocoderQuery } from '@opentripplanner/geocoder/lib/geocoders/types'
 
 // Types
 export type ServerlessEvent = {
@@ -126,6 +124,15 @@ export const arePointsRoughlyEqual = (
   )
 }
 
+const featureIsWithinDistance = (distanceMeters: number) =>
+  (feature: Feature): boolean => {
+  if (feature?.properties?.distance) {
+    const distance = feature.properties.distance
+    return distance > distanceMeters
+  }
+  return true
+}
+
 /**
  * Inspects a feature and removes it if a similar feature is included within a
  * second list of features
@@ -153,7 +160,7 @@ const filterOutDuplicateStops = (
 
   // Does a similar feature exist in the custom features
   const similarNameCustomFeature = checkNameDuplicates
-    ? customFeatures.find((otherFeature: Feature) =>
+    ? customFeatures.filter(featureIsWithinDistance(7500)).find((otherFeature: Feature) =>
         (feature?.properties?.name || '')
           .toLowerCase()
           .includes((otherFeature?.properties?.name || '').toLowerCase())


### PR DESCRIPTION
This PR does a lot of things. 
- the main behavior change is that unsatisfactory results will now be filtered out even if there's no backup geocoder configured UNLESS you specify skipSatisfactoryResultsCheck: true on the geocoder. Instead it just returns an empty array [] if they're unsatisfactory. The main reason for this change is that the OTP geocoder often returns very unsatisfactory results and we don't have a backup for it, so we need to just filter it out. I know we talked about using a dummy backup geocoder in the config for this situation but that really felt like a hack for something that should be supported natively in pelias stitch. Plus, something like that would be extremely opaque to people editing the config in the future. A deliberate config item is good. But I am not sure if changing the default behavior is a good idea. Maybe we can adjust this to find a better balance? 
- I adjusted the duplicates check to be more permissive, since it was removing pelias results that had any kind of similar name to an OTP results. The duplicate check now only applies to transit stops.
- Refactored the code so there is less business logic in handler. Since we can't directly test handler because of the environment variables, this was necessary for me to write the integration tests to test the dedupe and merge logic.
- I added "stops" to the list of preferred layers so that we can use the satisfies check on OTP geocoder without it filtering out everything. But we can't send stops as a layer to pelias so I split that out into PELIAS_LAYERS  